### PR TITLE
Upgrade Rust toolchain to version 1.85.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
           sudo apt-get install -y pkg-config libssl-dev libdbus-1-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1d2c4b624590a64002322b7093aad96383c8ce4e # 1.78.0
+        uses: dtolnay/rust-toolchain@1d2c4b624590a64002322b7093aad96383c8ce4e # 1.85.0
+        with:
+          toolchain: 1.85.0
 
       - name: Cache cargo registry & build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
Updated Rust toolchain version from 1.78.0 to 1.85.0 in the release workflow.