### PR TITLE
Update cargo publish command in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,6 @@ jobs:
         id: auth
 
       - name: Publish to crates.io
-        run: cargo publish --locked
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Removed the --locked flag from the cargo publish command.