### PR TITLE
Add internet radio tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Ferrosonic-ng is a continuation of the original [ferrosonic](https://github.com/
 - **Artist/album browser** — Tree-based navigation with expandable artists, album listings, and artist filtering
 - **Browse page** — Browse and search all, starred and random songs/albums from your server
 - **Playlists & queue management** — Browse server playlists, add/remove/reorder/shuffle queue, clear history
+- **Internet radio** — Browse and play Navidrome/Subsonic radio stations with live stream metadata when available
 - **Audio quality display** — Real-time sample rate, bit depth, codec, and channel layout
 - **Audio visualizer** — Integrated [cava](https://github.com/karlstav/cava) visualizer with theme-matched gradient colors
 - **13 built-in themes + custom themes** — Monokai, Dracula, Nord, Catppuccin, Tokyo Night, and more. Create your own as TOML files in `~/.config/ferrosonic/themes/`. See the [themes documentation](docs/themes.md)
@@ -85,7 +86,7 @@ ferrosonic -v
 
 ## Configuration
 
-Configuration is stored at `~/.config/ferrosonic/config.toml`. You can edit it manually or configure the server connection through the application's Server page (F5).
+Configuration is stored at `~/.config/ferrosonic/config.toml`. You can edit it manually or configure the server connection through the application's Server page (F6).
 
 ```toml
 BaseURL = "https://your-subsonic-server.com"

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -16,8 +16,9 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `F2` | Artists page |
 | `F3` | Queue page |
 | `F4` | Playlists page |
-| `F5` | Server configuration page |
-| `F6` | Settings page |
+| `F5` | Radio page |
+| `F6` | Server configuration page |
+| `F7` | Settings page |
 
 ## Songs Page (F1)
 
@@ -70,7 +71,19 @@ The Songs page has two modes selectable from the options pane: **Starred** (your
 | `n` | Add selected song as next in queue |
 | `s` | Shuffle play all songs in selected playlist |
 
-## Server Page (F5)
+## Radio Page (F5)
+
+| Key | Action |
+|---|---|
+| `Up` / `k` | Move selection up |
+| `Down` / `j` | Move selection down |
+| `Enter` | Play selected station |
+| `Space` | Play selected station, or toggle pause if it is already current |
+| `Ctrl+R` | Refresh all data, including radio stations |
+
+The Radio page lists internet radio stations from servers that support the Subsonic `getInternetRadioStations` endpoint, such as Navidrome.
+
+## Server Page (F6)
 
 | Key | Action |
 |---|---|
@@ -78,7 +91,7 @@ The Songs page has two modes selectable from the options pane: **Starred** (your
 | `Enter` | Test connection or Save configuration |
 | `Backspace` | Delete character in text field |
 
-## Settings Page (F6)
+## Settings Page (F7)
 
 | Key | Action |
 |---|---|

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -18,7 +18,7 @@ Ferrosonic ships with 13 themes. On first run, the built-in themes are written a
 | **One Dark** | Atom One Dark color scheme |
 | **Ayu Dark** | Ayu Dark color scheme |
 
-Change themes with `t` from any page, from the Settings page (F6), or by editing the `Theme` field in `config.toml`.
+Change themes with `t` from any page, from the Settings page (F7), or by editing the `Theme` field in `config.toml`.
 
 ### Custom Themes
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -105,10 +105,14 @@ impl App {
                 return Ok(());
             }
             (KeyCode::F(5), _) => {
-                state.page = Page::Server;
+                state.page = Page::Radio;
                 return Ok(());
             }
             (KeyCode::F(6), _) => {
+                state.page = Page::Server;
+                return Ok(());
+            }
+            (KeyCode::F(7), _) => {
                 state.page = Page::Settings;
                 return Ok(());
             }
@@ -166,6 +170,7 @@ impl App {
             Page::Artists => self.handle_artists_key(key).await,
             Page::Queue => self.handle_queue_key(key).await,
             Page::Playlists => self.handle_playlists_key(key).await,
+            Page::Radio => Ok(()),
             Page::Server => self.handle_server_key(key).await,
             Page::Settings => self.handle_settings_key(key).await,
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -118,6 +118,10 @@ impl App {
             }
             // Playback controls (global)
             (KeyCode::Char('p'), KeyModifiers::NONE) | (KeyCode::Char(' '), KeyModifiers::NONE) => {
+                if key.code == KeyCode::Char(' ') && state.page == Page::Radio {
+                    drop(state);
+                    return self.handle_radio_key(key).await;
+                }
                 // Toggle pause
                 drop(state);
                 return self.toggle_pause().await;
@@ -170,7 +174,7 @@ impl App {
             Page::Artists => self.handle_artists_key(key).await,
             Page::Queue => self.handle_queue_key(key).await,
             Page::Playlists => self.handle_playlists_key(key).await,
-            Page::Radio => Ok(()),
+            Page::Radio => self.handle_radio_key(key).await,
             Page::Server => self.handle_server_key(key).await,
             Page::Settings => self.handle_settings_key(key).await,
         }

--- a/src/app/input_radio.rs
+++ b/src/app/input_radio.rs
@@ -51,6 +51,9 @@ impl App {
                     }
                     return self.play_radio_station(station).await;
                 }
+
+                drop(state);
+                return self.toggle_pause().await;
             }
             _ => {}
         }

--- a/src/app/input_radio.rs
+++ b/src/app/input_radio.rs
@@ -1,0 +1,67 @@
+use crossterm::event::{self, KeyCode};
+
+use crate::error::Error;
+use crate::subsonic::models::InternetRadioStation;
+
+use super::*;
+
+impl App {
+    /// Handle radio page keys
+    pub(super) async fn handle_radio_key(&mut self, key: event::KeyEvent) -> Result<(), Error> {
+        let mut state = self.state.write().await;
+
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let Some(sel) = state.radio.selected {
+                    if sel > 0 {
+                        state.radio.selected = Some(sel - 1);
+                    }
+                } else if !state.radio.stations.is_empty() {
+                    state.radio.selected = Some(0);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let max = state.radio.stations.len().saturating_sub(1);
+                if let Some(sel) = state.radio.selected {
+                    if sel < max {
+                        state.radio.selected = Some(sel + 1);
+                    }
+                } else if !state.radio.stations.is_empty() {
+                    state.radio.selected = Some(0);
+                }
+            }
+            KeyCode::Enter => {
+                if let Some(station) = selected_station(&state) {
+                    drop(state);
+                    return self.play_radio_station(station).await;
+                }
+            }
+            KeyCode::Char(' ') => {
+                if let Some(station) = selected_station(&state) {
+                    let is_current = state
+                        .now_playing
+                        .radio_station
+                        .as_ref()
+                        .map(|current| current.id == station.id)
+                        .unwrap_or(false);
+                    drop(state);
+
+                    if is_current {
+                        return self.toggle_pause().await;
+                    }
+                    return self.play_radio_station(station).await;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+}
+
+fn selected_station(state: &AppState) -> Option<InternetRadioStation> {
+    state
+        .radio
+        .selected
+        .and_then(|idx| state.radio.stations.get(idx).cloned())
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -15,6 +15,7 @@ mod mouse;
 mod mouse_artists;
 mod mouse_browse;
 mod mouse_playlists;
+mod mouse_radio;
 mod notifications;
 mod playback;
 mod repo;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ mod input_artists;
 mod input_browse;
 mod input_playlists;
 mod input_queue;
+mod input_radio;
 mod input_server;
 mod input_settings;
 pub mod models;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -234,6 +234,7 @@ impl App {
         self.get_all_songs(false).await;
         self.get_artists().await;
         self.get_playlists().await;
+        self.get_radio_stations().await;
     }
 
     /// Main event loop

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -123,6 +123,7 @@ impl App {
             Page::Artists => self.handle_artists_click(x, y, layout).await,
             Page::Queue => self.handle_queue_click(y, layout).await,
             Page::Playlists => self.handle_playlists_click(x, y, layout).await,
+            Page::Radio => self.handle_radio_click(x, y, layout).await,
             _ => Ok(()),
         }
     }
@@ -213,6 +214,20 @@ impl App {
                     if sel > 0 {
                         state.playlists.selected_song = Some(sel - 1);
                     }
+                }
+            }
+            Page::Radio => {
+                if let Some(sel) = state.radio.selected {
+                    if sel > 0 {
+                        let new_sel = sel - 1;
+                        state.radio.selected = Some(new_sel);
+                        if new_sel < state.radio.scroll_offset {
+                            state.radio.scroll_offset = new_sel;
+                        }
+                    }
+                } else if !state.radio.stations.is_empty() {
+                    state.radio.selected = Some(0);
+                    state.radio.scroll_offset = 0;
                 }
             }
             _ => {}
@@ -337,6 +352,22 @@ impl App {
                     } else if !state.playlists.songs.is_empty() {
                         state.playlists.selected_song = Some(0);
                     }
+                }
+            }
+            Page::Radio => {
+                let max = state.radio.stations.len().saturating_sub(1);
+                if let Some(sel) = state.radio.selected {
+                    if sel < max {
+                        let new_sel = sel + 1;
+                        state.radio.selected = Some(new_sel);
+                        let viewport = state.layout.content.height.saturating_sub(2) as usize;
+                        if viewport > 0 && new_sel >= state.radio.scroll_offset + viewport {
+                            state.radio.scroll_offset = new_sel + 1 - viewport;
+                        }
+                    }
+                } else if !state.radio.stations.is_empty() {
+                    state.radio.selected = Some(0);
+                    state.radio.scroll_offset = 0;
                 }
             }
             _ => {}

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -26,6 +26,7 @@ impl App {
         let layout = state.layout.clone();
         let page = state.page;
         let duration = state.now_playing.duration;
+        let radio_active = state.now_playing.radio_station.is_some();
         drop(state);
 
         // Check header area
@@ -80,7 +81,7 @@ impl App {
         // Check now playing area (progress bar seeking)
         if y >= layout.now_playing.y && y < layout.now_playing.y + layout.now_playing.height {
             let inner_bottom = layout.now_playing.y + layout.now_playing.height - 2;
-            if y == inner_bottom && duration > 0.0 {
+            if y == inner_bottom && duration > 0.0 && !radio_active {
                 let inner_x_start = layout.now_playing.x + 1;
                 let inner_width = layout.now_playing.width.saturating_sub(2);
                 if inner_width > 15 && x >= inner_x_start {

--- a/src/app/mouse_artists.rs
+++ b/src/app/mouse_artists.rs
@@ -162,6 +162,9 @@ impl App {
                     state.queue.extend(songs);
                     state.queue_position = Some(item_index);
                     state.now_playing.song = Some(song.clone());
+                    state.now_playing.radio_station = None;
+                    state.now_playing.radio_title = None;
+                    state.now_playing.radio_artist = None;
                     state.now_playing.state = PlaybackState::Playing;
                     state.now_playing.position = 0.0;
                     state.now_playing.duration = song.duration.unwrap_or(0) as f64;

--- a/src/app/mouse_radio.rs
+++ b/src/app/mouse_radio.rs
@@ -1,0 +1,39 @@
+use crate::error::Error;
+
+use super::*;
+
+impl App {
+    /// Handle click on radio page
+    pub(super) async fn handle_radio_click(
+        &mut self,
+        x: u16,
+        y: u16,
+        layout: &LayoutAreas,
+    ) -> Result<(), Error> {
+        let mut state = self.state.write().await;
+        let content = layout.content;
+
+        let row_in_viewport = y.saturating_sub(content.y + 1) as usize;
+        let item_index = state.radio.scroll_offset + row_in_viewport;
+
+        if item_index < state.radio.stations.len() {
+            let was_selected = state.radio.selected == Some(item_index);
+            state.radio.selected = Some(item_index);
+
+            let is_second_click = was_selected
+                && self
+                    .last_click
+                    .is_some_and(|(lx, ly, t)| lx == x && ly == y && t.elapsed().as_millis() < 500);
+
+            if is_second_click {
+                let station = state.radio.stations[item_index].clone();
+                drop(state);
+                self.last_click = Some((x, y, std::time::Instant::now()));
+                return self.play_radio_station(station).await;
+            }
+        }
+
+        self.last_click = Some((x, y, std::time::Instant::now()));
+        Ok(())
+    }
+}

--- a/src/app/mouse_radio.rs
+++ b/src/app/mouse_radio.rs
@@ -23,7 +23,7 @@ impl App {
             let is_second_click = was_selected
                 && self
                     .last_click
-                    .is_some_and(|(lx, ly, t)| lx == x && ly == y && t.elapsed().as_millis() < 500);
+                    .is_some_and(|(_, ly, t)| ly == y && t.elapsed().as_millis() < 500);
 
             if is_second_click {
                 let station = state.radio.stations[item_index].clone();

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -125,6 +125,14 @@ impl App {
                         state.now_playing.radio_artist = None;
                         state.now_playing.position = 0.0;
                         state.now_playing.duration = 0.0;
+                        drop(state);
+
+                        if let Some(ref server) = self.mpris_server {
+                            if let Err(e) = update_mpris_properties(server, &self.state).await {
+                                debug!("Failed to update MPRIS properties: {}", e);
+                            }
+                        }
+
                         return;
                     }
 

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -1,4 +1,5 @@
 use crate::app::notifications::TrackInfo;
+use crate::subsonic::models::InternetRadioStation;
 use tracing::{debug, error, info, warn};
 
 use super::*;
@@ -83,6 +84,9 @@ impl App {
                             state.queue_position = Some(next_pos);
                             if let Some(song) = state.queue.get(next_pos).cloned() {
                                 state.now_playing.song = Some(song.clone());
+                                state.now_playing.radio_station = None;
+                                state.now_playing.radio_title = None;
+                                state.now_playing.radio_artist = None;
                                 state.now_playing.position = 0.0;
                                 state.now_playing.duration = song.duration.unwrap_or(0) as f64;
                                 state.now_playing.scrobbled = false;
@@ -108,6 +112,18 @@ impl App {
             // Check if MPV went idle (track ended, no preloaded track)
             if let Ok(idle) = self.mpv.is_idle() {
                 if idle {
+                    let is_radio = {
+                        let state = self.state.read().await;
+                        state.now_playing.radio_station.is_some()
+                    };
+                    if is_radio {
+                        info!("Radio stream went idle, stopping playback");
+                        let mut state = self.state.write().await;
+                        state.now_playing.state = PlaybackState::Stopped;
+                        state.now_playing.position = 0.0;
+                        return;
+                    }
+
                     info!("Track ended, advancing to next");
                     let _ = self.next_track().await;
                     return;
@@ -125,13 +141,14 @@ impl App {
         {
             let (should_check, position, duration, song_id) = {
                 let state = self.state.read().await;
+                let song_id = state.now_playing.song.as_ref().map(|s| s.id.clone());
                 let should_check = state.settings_state.scrobble_enabled
                     && !state.now_playing.scrobbled
                     && state.now_playing.state == PlaybackState::Playing
-                    && state.now_playing.duration > 0.0;
+                    && state.now_playing.duration > 0.0
+                    && song_id.is_some();
                 let position = state.now_playing.position;
                 let duration = state.now_playing.duration;
-                let song_id = state.now_playing.song.as_ref().map(|s| s.id.clone());
                 (should_check, position, duration, song_id)
             };
 
@@ -381,6 +398,9 @@ impl App {
             let mut state = self.state.write().await;
             state.queue_position = Some(pos);
             state.now_playing.song = Some(song.clone());
+            state.now_playing.radio_station = None;
+            state.now_playing.radio_title = None;
+            state.now_playing.radio_artist = None;
             state.now_playing.state = PlaybackState::Playing;
             state.now_playing.position = 0.0;
             state.now_playing.duration = song.duration.unwrap_or(0) as f64;
@@ -403,6 +423,45 @@ impl App {
         }
 
         self.preload_next_track(pos).await;
+
+        Ok(())
+    }
+
+    /// Play an internet radio station by direct stream URL
+    pub(super) async fn play_radio_station(
+        &mut self,
+        station: InternetRadioStation,
+    ) -> Result<(), Error> {
+        {
+            let mut state = self.state.write().await;
+            state.queue.clear();
+            state.queue_position = None;
+            state.queue_state.selected = None;
+            state.now_playing.song = None;
+            state.now_playing.radio_station = Some(station.clone());
+            state.now_playing.radio_title = None;
+            state.now_playing.radio_artist = None;
+            state.now_playing.state = PlaybackState::Playing;
+            state.now_playing.position = 0.0;
+            state.now_playing.duration = 0.0;
+            state.now_playing.sample_rate = None;
+            state.now_playing.bit_depth = None;
+            state.now_playing.format = None;
+            state.now_playing.channels = None;
+            state.now_playing.scrobbled = false;
+            state.notify(format!("Playing radio: {}", station.name));
+        }
+
+        info!("Playing radio: {}", station.name);
+        if self.mpv.is_paused().unwrap_or(false) {
+            let _ = self.mpv.resume();
+        }
+        if let Err(e) = self.mpv.loadfile(&station.stream_url) {
+            error!("Failed to play radio: {}", e);
+            let mut state = self.state.write().await;
+            state.now_playing.state = PlaybackState::Stopped;
+            state.notify_error(format!("MPV error: {}", e));
+        }
 
         Ok(())
     }
@@ -450,6 +509,9 @@ impl App {
         let mut state = self.state.write().await;
         state.now_playing.state = PlaybackState::Stopped;
         state.now_playing.song = None;
+        state.now_playing.radio_station = None;
+        state.now_playing.radio_title = None;
+        state.now_playing.radio_artist = None;
         state.now_playing.position = 0.0;
         state.now_playing.duration = 0.0;
         state.now_playing.sample_rate = None;

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -120,7 +120,11 @@ impl App {
                         info!("Radio stream went idle, stopping playback");
                         let mut state = self.state.write().await;
                         state.now_playing.state = PlaybackState::Stopped;
+                        state.now_playing.radio_station = None;
+                        state.now_playing.radio_title = None;
+                        state.now_playing.radio_artist = None;
                         state.now_playing.position = 0.0;
+                        state.now_playing.duration = 0.0;
                         return;
                     }
 
@@ -480,6 +484,11 @@ impl App {
             error!("Failed to play radio: {}", e);
             let mut state = self.state.write().await;
             state.now_playing.state = PlaybackState::Stopped;
+            state.now_playing.radio_station = None;
+            state.now_playing.radio_title = None;
+            state.now_playing.radio_artist = None;
+            state.now_playing.position = 0.0;
+            state.now_playing.duration = 0.0;
             state.notify_error(format!("MPV error: {}", e));
         }
 

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -137,6 +137,26 @@ impl App {
             state.now_playing.position = position;
         }
 
+        // Update live metadata for radio streams.
+        {
+            let is_radio = {
+                let state = self.state.read().await;
+                state.now_playing.radio_station.is_some()
+            };
+
+            if is_radio {
+                if let Ok(metadata) = self.mpv.get_radio_metadata() {
+                    let mut state = self.state.write().await;
+                    if state.now_playing.radio_title != metadata.title {
+                        state.now_playing.radio_title = metadata.title;
+                    }
+                    if state.now_playing.radio_artist != metadata.artist {
+                        state.now_playing.radio_artist = metadata.artist;
+                    }
+                }
+            }
+        }
+
         // Check scrobble threshold: 50% of duration or 4 minutes, whichever comes first
         {
             let (should_check, position, duration, song_id) = {

--- a/src/app/repo.rs
+++ b/src/app/repo.rs
@@ -216,6 +216,26 @@ impl App {
         }
     }
 
+    pub async fn get_radio_stations(&mut self) {
+        if let Some(ref client) = self.subsonic {
+            match client.get_internet_radio_stations().await {
+                Ok(stations) => {
+                    let mut state = self.state.write().await;
+                    let count = stations.len();
+                    state.radio.stations = stations;
+                    state.radio.selected = if count > 0 { Some(0) } else { None };
+                    state.radio.scroll_offset = 0;
+                    info!("Loaded {} radio stations", count);
+                }
+                Err(e) => {
+                    error!("Failed to load radio stations: {}", e);
+                    let mut state = self.state.write().await;
+                    state.notify_error(format!("Failed to load radio stations: {}", e));
+                }
+            }
+        }
+    }
+
     pub async fn unstar_song(&mut self, id: String) {
         if let Some(ref client) = self.subsonic {
             match client.unstar_song(&id).await {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -8,7 +8,7 @@ use ratatui::layout::Rect;
 
 use crate::app::models::{BrowseTab, SongOption};
 use crate::config::Config;
-use crate::subsonic::models::{Album, Artist, Child, Playlist};
+use crate::subsonic::models::{Album, Artist, Child, InternetRadioStation, Playlist};
 use crate::ui::theme::{ThemeColors, ThemeData};
 
 /// Current page in the application
@@ -19,6 +19,7 @@ pub enum Page {
     Artists,
     Queue,
     Playlists,
+    Radio,
     Server,
     Settings,
 }
@@ -30,8 +31,9 @@ impl Page {
             Page::Artists => 1,
             Page::Queue => 2,
             Page::Playlists => 3,
-            Page::Server => 4,
-            Page::Settings => 5,
+            Page::Radio => 4,
+            Page::Server => 5,
+            Page::Settings => 6,
         }
     }
 
@@ -41,6 +43,7 @@ impl Page {
             Page::Artists => "Artists",
             Page::Queue => "Queue",
             Page::Playlists => "Playlists",
+            Page::Radio => "Radio",
             Page::Server => "Server",
             Page::Settings => "Settings",
         }
@@ -52,8 +55,9 @@ impl Page {
             Page::Artists => "F2",
             Page::Queue => "F3",
             Page::Playlists => "F4",
-            Page::Server => "F5",
-            Page::Settings => "F6",
+            Page::Radio => "F5",
+            Page::Server => "F6",
+            Page::Settings => "F7",
         }
     }
 }
@@ -72,6 +76,12 @@ pub enum PlaybackState {
 pub struct NowPlaying {
     /// Currently playing song
     pub song: Option<Child>,
+    /// Currently playing internet radio station
+    pub radio_station: Option<InternetRadioStation>,
+    /// Current radio stream title from player metadata
+    pub radio_title: Option<String>,
+    /// Current radio stream artist from player metadata
+    pub radio_artist: Option<String>,
     /// Playback state
     pub state: PlaybackState,
     /// Current position in seconds
@@ -290,6 +300,17 @@ pub struct PlaylistsState {
     pub song_scroll_offset: usize,
 }
 
+/// Radio page state
+#[derive(Debug, Clone, Default)]
+pub struct RadioState {
+    /// List of all internet radio stations
+    pub stations: Vec<InternetRadioStation>,
+    /// Currently selected station index
+    pub selected: Option<usize>,
+    /// Scroll offset for the station list (set after render)
+    pub scroll_offset: usize,
+}
+
 /// Server page state (connection settings)
 #[derive(Debug, Clone, Default)]
 pub struct ServerState {
@@ -420,6 +441,8 @@ pub struct AppState {
     pub queue_state: QueueState,
     /// Playlists page state
     pub playlists: PlaylistsState,
+    /// Radio page state
+    pub radio: RadioState,
     /// Server page state (connection settings)
     pub server_state: ServerState,
     /// Settings page state (app preferences)

--- a/src/audio/mpv.rs
+++ b/src/audio/mpv.rs
@@ -14,6 +14,13 @@ use tracing::{debug, info, trace};
 use crate::config::paths::mpv_socket_path;
 use crate::error::AudioError;
 
+/// Parsed live metadata for an internet radio stream.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RadioMetadata {
+    pub title: Option<String>,
+    pub artist: Option<String>,
+}
+
 /// MPV IPC command
 #[derive(Debug, Serialize)]
 struct MpvCommand {
@@ -134,7 +141,10 @@ impl MpvController {
     /// Send a command to MPV
     fn send_command(&mut self, args: Vec<Value>) -> Result<Option<Value>, AudioError> {
         let result = self.try_send_command(args);
-        if matches!(&result, Err(AudioError::MpvIpc(_) | AudioError::MpvSocket(_))) {
+        if matches!(
+            &result,
+            Err(AudioError::MpvIpc(_) | AudioError::MpvSocket(_))
+        ) {
             self.socket = None;
         }
         result
@@ -349,6 +359,12 @@ impl MpvController {
         }))
     }
 
+    /// Get parsed live metadata for radio streams.
+    pub fn get_radio_metadata(&mut self) -> Result<RadioMetadata, AudioError> {
+        let data = self.send_command(vec![json!("get_property"), json!("metadata")])?;
+        Ok(data.as_ref().map(parse_radio_metadata).unwrap_or_default())
+    }
+
     /// Check if anything is loaded
     pub fn is_idle(&mut self) -> Result<bool, AudioError> {
         let data = self.send_command(vec![json!("get_property"), json!("idle-active")])?;
@@ -372,7 +388,95 @@ impl MpvController {
         info!("MPV shut down");
         Ok(())
     }
+}
 
+fn parse_radio_metadata(metadata: &Value) -> RadioMetadata {
+    let artist = metadata_string(metadata, "artist");
+    let title = metadata_string(metadata, "title");
+
+    if artist.is_some() && title.is_some() {
+        return RadioMetadata { title, artist };
+    }
+
+    if let Some(icy_title) = metadata_string(metadata, "icy-title") {
+        if let Some((artist, title)) = split_icy_title(&icy_title) {
+            return RadioMetadata {
+                title: Some(title),
+                artist: Some(artist),
+            };
+        }
+
+        return RadioMetadata {
+            title: Some(icy_title),
+            artist,
+        };
+    }
+
+    RadioMetadata { title, artist }
+}
+
+fn metadata_string(metadata: &Value, key: &str) -> Option<String> {
+    metadata
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn split_icy_title(value: &str) -> Option<(String, String)> {
+    let (artist, title) = value.split_once(" - ")?;
+    let artist = artist.trim();
+    let title = title.trim();
+    if artist.is_empty() || title.is_empty() {
+        None
+    } else {
+        Some((artist.to_string(), title.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_artist_and_title_metadata() {
+        let metadata = json!({ "artist": "Artist", "title": "Track" });
+
+        assert_eq!(
+            parse_radio_metadata(&metadata),
+            RadioMetadata {
+                title: Some("Track".to_string()),
+                artist: Some("Artist".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn splits_icy_title_artist_title() {
+        let metadata = json!({ "icy-title": "Artist - Track" });
+
+        assert_eq!(
+            parse_radio_metadata(&metadata),
+            RadioMetadata {
+                title: Some("Track".to_string()),
+                artist: Some("Artist".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn uses_raw_icy_title_when_unsplittable() {
+        let metadata = json!({ "icy-title": "Live Stream Title" });
+
+        assert_eq!(
+            parse_radio_metadata(&metadata),
+            RadioMetadata {
+                title: Some("Live Stream Title".to_string()),
+                artist: None,
+            }
+        );
+    }
 }
 
 impl Drop for MpvController {

--- a/src/mpris/server.rs
+++ b/src/mpris/server.rs
@@ -40,6 +40,90 @@ fn build_cover_art_url(config: &Config, cover_art_id: &str) -> Option<String> {
     Some(url.to_string())
 }
 
+fn mpris_path_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn build_metadata(
+    now_playing: &NowPlaying,
+    current_song: Option<Child>,
+    config: &Config,
+) -> Metadata {
+    let mut metadata = Metadata::new();
+
+    if let Some(song) = current_song {
+        metadata.set_trackid(
+            Some(TrackId::try_from(format!("/org/mpris/MediaPlayer2/Track/{}", song.id)).ok())
+                .flatten(),
+        );
+        metadata.set_title(Some(song.title));
+        metadata.set_artist(song.artist.map(|a| vec![a]));
+        metadata.set_album(song.album);
+
+        if let Some(duration) = song.duration {
+            metadata.set_length(Some(Time::from_micros(duration as i64 * 1_000_000)));
+        }
+
+        if let Some(track) = song.track {
+            metadata.set_track_number(Some(track));
+        }
+
+        if let Some(disc) = song.disc_number {
+            metadata.set_disc_number(Some(disc));
+        }
+
+        if let Some(ref cover_art_id) = song.cover_art {
+            if let Some(cover_url) = build_cover_art_url(config, cover_art_id) {
+                metadata.set_art_url(Some(cover_url));
+            }
+        }
+    } else if let Some(station) = now_playing.radio_station.as_ref() {
+        metadata.set_trackid(
+            Some(
+                TrackId::try_from(format!(
+                    "/org/mpris/MediaPlayer2/Radio/{}",
+                    mpris_path_segment(&station.id)
+                ))
+                .ok(),
+            )
+            .flatten(),
+        );
+        metadata.set_title(Some(
+            now_playing
+                .radio_title
+                .clone()
+                .unwrap_or_else(|| station.name.clone()),
+        ));
+        metadata.set_artist(Some(vec![now_playing
+            .radio_artist
+            .clone()
+            .unwrap_or_else(|| "Internet Radio".to_string())]));
+        metadata.set_album(
+            station
+                .home_page_url
+                .clone()
+                .or_else(|| Some(station.name.clone())),
+        );
+
+        if let Some(ref cover_art_id) = station.cover_art {
+            if let Some(cover_url) = build_cover_art_url(config, cover_art_id) {
+                metadata.set_art_url(Some(cover_url));
+            }
+        }
+    }
+
+    metadata
+}
+
 /// MPRIS server instance name
 const PLAYER_NAME: &str = "ferrosonic";
 
@@ -207,40 +291,8 @@ impl PlayerInterface for MprisPlayer {
     }
 
     async fn metadata(&self) -> fdo::Result<Metadata> {
-        let (_now_playing, current_song, config) = self.get_state().await;
-
-        let mut metadata = Metadata::new();
-
-        if let Some(song) = current_song {
-            metadata.set_trackid(
-                Some(TrackId::try_from(format!("/org/mpris/MediaPlayer2/Track/{}", song.id)).ok())
-                    .flatten(),
-            );
-            metadata.set_title(Some(song.title));
-            metadata.set_artist(song.artist.map(|a| vec![a]));
-            metadata.set_album(song.album);
-
-            if let Some(duration) = song.duration {
-                metadata.set_length(Some(Time::from_micros(duration as i64 * 1_000_000)));
-            }
-
-            if let Some(track) = song.track {
-                metadata.set_track_number(Some(track));
-            }
-
-            if let Some(disc) = song.disc_number {
-                metadata.set_disc_number(Some(disc));
-            }
-
-            // Add cover art URL
-            if let Some(ref cover_art_id) = song.cover_art {
-                if let Some(cover_url) = build_cover_art_url(&config, cover_art_id) {
-                    metadata.set_art_url(Some(cover_url));
-                }
-            }
-        }
-
-        Ok(metadata)
+        let (now_playing, current_song, config) = self.get_state().await;
+        Ok(build_metadata(&now_playing, current_song, &config))
     }
 
     async fn volume(&self) -> fdo::Result<Volume> {
@@ -283,7 +335,7 @@ impl PlayerInterface for MprisPlayer {
 
     async fn can_play(&self) -> fdo::Result<bool> {
         let state = self.state.read().await;
-        Ok(!state.queue.is_empty())
+        Ok(!state.queue.is_empty() || state.now_playing.radio_station.is_some())
     }
 
     async fn can_pause(&self) -> fdo::Result<bool> {
@@ -291,7 +343,8 @@ impl PlayerInterface for MprisPlayer {
     }
 
     async fn can_seek(&self) -> fdo::Result<bool> {
-        Ok(true)
+        let state = self.state.read().await;
+        Ok(state.now_playing.radio_station.is_none())
     }
 
     async fn can_control(&self) -> fdo::Result<bool> {
@@ -338,31 +391,18 @@ pub async fn update_mpris_properties(
                     .unwrap_or(false),
             ),
             Property::CanGoPrevious(state.queue_position.map(|p| p > 0).unwrap_or(false)),
+            Property::CanPlay(!state.queue.is_empty() || state.now_playing.radio_station.is_some()),
+            Property::CanSeek(state.now_playing.radio_station.is_none()),
         ])
         .await?;
 
-    // Update metadata if we have a current song
-    if let Some(song) = state.current_song() {
-        let mut metadata = Metadata::new();
-        metadata.set_trackid(
-            Some(TrackId::try_from(format!("/org/mpris/MediaPlayer2/Track/{}", song.id)).ok())
-                .flatten(),
+    // Update metadata if we have a current song or radio station
+    if state.current_song().is_some() || state.now_playing.radio_station.is_some() {
+        let metadata = build_metadata(
+            &state.now_playing,
+            state.current_song().cloned(),
+            &state.config,
         );
-        metadata.set_title(Some(song.title.clone()));
-        metadata.set_artist(song.artist.clone().map(|a| vec![a]));
-        metadata.set_album(song.album.clone());
-
-        if let Some(duration) = song.duration {
-            metadata.set_length(Some(Time::from_micros(duration as i64 * 1_000_000)));
-        }
-
-        // Add cover art URL
-        if let Some(ref cover_art_id) = song.cover_art {
-            if let Some(cover_url) = build_cover_art_url(&state.config, cover_art_id) {
-                metadata.set_art_url(Some(cover_url));
-            }
-        }
-
         server
             .properties_changed([Property::Metadata(metadata)])
             .await?;
@@ -382,7 +422,10 @@ mod tests {
         let player = MprisPlayer::new(new_shared_state(Config::new()), audio_tx);
 
         assert_eq!(
-            player.identity().await.expect("identity should be available"),
+            player
+                .identity()
+                .await
+                .expect("identity should be available"),
             "Ferrosonic"
         );
     }

--- a/src/subsonic/client.rs
+++ b/src/subsonic/client.rs
@@ -334,6 +334,16 @@ impl SubsonicClient {
         Ok(playlists)
     }
 
+    /// Get internet radio stations
+    pub async fn get_internet_radio_stations(
+        &self,
+    ) -> Result<Vec<InternetRadioStation>, SubsonicError> {
+        let data: InternetRadioStationsData = self.request("getInternetRadioStations").await?;
+        let stations = data.internet_radio_stations.internet_radio_station;
+        debug!("Fetched {} internet radio stations", stations.len());
+        Ok(stations)
+    }
+
     /// Get playlist details with songs
     pub async fn get_playlist(&self, id: &str) -> Result<(Playlist, Vec<Child>), SubsonicError> {
         let mut url = self.build_url("getPlaylist")?;

--- a/src/subsonic/models.rs
+++ b/src/subsonic/models.rs
@@ -247,6 +247,32 @@ pub struct PlaylistDetail {
     pub entry: Vec<Child>,
 }
 
+/// Internet radio stations response
+#[derive(Debug, Deserialize)]
+pub struct InternetRadioStationsData {
+    #[serde(rename = "internetRadioStations")]
+    pub internet_radio_stations: InternetRadioStationsInner,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InternetRadioStationsInner {
+    #[serde(rename = "internetRadioStation", default)]
+    pub internet_radio_station: Vec<InternetRadioStation>,
+}
+
+/// Internet radio station
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InternetRadioStation {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "streamUrl")]
+    pub stream_url: String,
+    #[serde(default, rename = "homePageUrl")]
+    pub home_page_url: Option<String>,
+    #[serde(default, rename = "coverArt")]
+    pub cover_art: Option<String>,
+}
+
 /// Search3 response wrapper
 #[derive(Debug, Deserialize)]
 pub struct Search3Data {

--- a/src/subsonic/tests.rs
+++ b/src/subsonic/tests.rs
@@ -342,6 +342,104 @@ async fn get_playlist_api_error() {
     assert!(matches!(err, SubsonicError::Api { code: 70, .. }));
 }
 
+#[tokio::test]
+async fn get_internet_radio_stations_ok() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/rest/getInternetRadioStations");
+            then.status(200).body(
+                r#"{
+                    "subsonic-response": {
+                        "status": "ok",
+                        "version": "1.16.1",
+                        "internetRadioStations": {
+                            "internetRadioStation": [
+                                {
+                                    "id": "ir-1",
+                                    "name": "Station One",
+                                    "streamUrl": "https://example.com/radio.mp3",
+                                    "homePageUrl": "https://example.com",
+                                    "coverArt": "ir-1"
+                                },
+                                {
+                                    "id": "ir-2",
+                                    "name": "Station Two",
+                                    "streamUrl": "https://example.com/second.aac"
+                                }
+                            ]
+                        }
+                    }
+                }"#,
+            );
+        })
+        .await;
+
+    let stations = make_client(&server)
+        .get_internet_radio_stations()
+        .await
+        .unwrap();
+    assert_eq!(stations.len(), 2);
+    assert_eq!(stations[0].id, "ir-1");
+    assert_eq!(stations[0].name, "Station One");
+    assert_eq!(stations[0].stream_url, "https://example.com/radio.mp3");
+    assert_eq!(
+        stations[0].home_page_url.as_deref(),
+        Some("https://example.com")
+    );
+    assert_eq!(stations[0].cover_art.as_deref(), Some("ir-1"));
+    assert_eq!(stations[1].home_page_url, None);
+    assert_eq!(stations[1].cover_art, None);
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn get_internet_radio_stations_empty() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET).path("/rest/getInternetRadioStations");
+            then.status(200).body(
+                r#"{
+                    "subsonic-response": {
+                        "status": "ok",
+                        "version": "1.16.1",
+                        "internetRadioStations": {
+                            "internetRadioStation": []
+                        }
+                    }
+                }"#,
+            );
+        })
+        .await;
+
+    let stations = make_client(&server)
+        .get_internet_radio_stations()
+        .await
+        .unwrap();
+    assert!(stations.is_empty());
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn get_internet_radio_stations_api_error() {
+    let server = MockServer::start_async().await;
+    server
+        .mock_async(|when, then| {
+            when.method(GET).path("/rest/getInternetRadioStations");
+            then.status(200).body(
+                r#"{"subsonic-response":{"status":"failed","version":"1.16.1","error":{"code":70,"message":"Radio stations unavailable"}}}"#,
+            );
+        })
+        .await;
+
+    let err = make_client(&server)
+        .get_internet_radio_stations()
+        .await
+        .unwrap_err();
+    assert!(matches!(err, SubsonicError::Api { code: 70, .. }));
+}
+
 // get_starred_songs
 #[tokio::test]
 async fn get_starred_songs_ok() {

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -90,6 +90,13 @@ impl<'a> Footer<'a> {
                     ("s", "Shuffle play"),
                 ]);
             }
+            Page::Radio => {
+                binds.extend([
+                    ("Enter", "Play"),
+                    ("Space", "Play/Pause"),
+                    ("Ctrl+R", "Refresh"),
+                ]);
+            }
             Page::Server => {
                 binds.extend([
                     ("Tab", "Next field"),

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -43,6 +43,7 @@ impl Widget for Header {
             Page::Artists,
             Page::Queue,
             Page::Playlists,
+            Page::Radio,
             Page::Server,
             Page::Settings,
         ]
@@ -120,6 +121,7 @@ impl Header {
                 Page::Artists,
                 Page::Queue,
                 Page::Playlists,
+                Page::Radio,
                 Page::Server,
                 Page::Settings,
             ];

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -91,6 +91,7 @@ pub fn draw(frame: &mut Frame, state: &mut AppState) {
         Page::Playlists => {
             pages::playlists::render(frame, content_area, state);
         }
+        Page::Radio => {}
         Page::Server => {
             pages::server::render(frame, content_area, state);
         }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -91,7 +91,9 @@ pub fn draw(frame: &mut Frame, state: &mut AppState) {
         Page::Playlists => {
             pages::playlists::render(frame, content_area, state);
         }
-        Page::Radio => {}
+        Page::Radio => {
+            pages::radio::render(frame, content_area, state);
+        }
         Page::Server => {
             pages::server::render(frame, content_area, state);
         }

--- a/src/ui/pages/mod.rs
+++ b/src/ui/pages/mod.rs
@@ -4,5 +4,6 @@ pub mod artists;
 pub mod browse;
 pub mod playlists;
 pub mod queue;
+pub mod radio;
 pub mod server;
 pub mod settings;

--- a/src/ui/pages/radio.rs
+++ b/src/ui/pages/radio.rs
@@ -1,0 +1,96 @@
+//! Radio page showing internet radio stations
+
+use ratatui::{
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame,
+};
+
+use crate::app::state::AppState;
+
+/// Render the radio page
+pub fn render(frame: &mut Frame, area: Rect, state: &mut AppState) {
+    let colors = *state.settings_state.theme_colors();
+    let radio = &state.radio;
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Radio ({}) ", radio.stations.len()))
+        .border_style(Style::default().fg(colors.border_focused));
+
+    if radio.stations.is_empty() {
+        let hint = Paragraph::new("No radio stations found")
+            .style(Style::default().fg(colors.muted))
+            .block(block);
+        frame.render_widget(hint, area);
+        return;
+    }
+
+    let current_station_id = state
+        .now_playing
+        .radio_station
+        .as_ref()
+        .map(|station| station.id.as_str());
+
+    let items: Vec<ListItem> = radio
+        .stations
+        .iter()
+        .enumerate()
+        .map(|(i, station)| {
+            let is_selected = radio.selected == Some(i);
+            let is_current = current_station_id == Some(station.id.as_str());
+            let detail = station
+                .home_page_url
+                .as_deref()
+                .unwrap_or(station.stream_url.as_str());
+
+            let (name_style, detail_style) = if is_selected {
+                (
+                    Style::default()
+                        .fg(colors.highlight_fg)
+                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(colors.highlight_fg),
+                )
+            } else if is_current {
+                (
+                    Style::default()
+                        .fg(colors.playing)
+                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(colors.muted),
+                )
+            } else {
+                (
+                    Style::default().fg(colors.song),
+                    Style::default().fg(colors.muted),
+                )
+            };
+
+            let indicator = if is_current { "▶ " } else { "  " };
+            let line = Line::from(vec![
+                Span::styled(format!("{:3}. ", i + 1), Style::default().fg(colors.muted)),
+                Span::styled(indicator, Style::default().fg(colors.playing)),
+                Span::styled(&station.name, name_style),
+                Span::styled(format!(" — {}", detail), detail_style),
+            ]);
+
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(
+            Style::default()
+                .bg(colors.highlight_bg)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut list_state = ListState::default();
+    list_state.select(radio.selected);
+
+    frame.render_stateful_widget(list, area, &mut list_state);
+    state.radio.scroll_offset = list_state.offset();
+}

--- a/src/ui/widgets/now_playing.rs
+++ b/src/ui/widgets/now_playing.rs
@@ -58,11 +58,118 @@ impl Widget for NowPlayingWidget<'_> {
         }
 
         // Check if something is playing
-        if self.now_playing.song.is_none() {
+        if self.now_playing.song.is_none() && self.now_playing.radio_station.is_none() {
             let no_track = Paragraph::new("No track playing")
                 .style(Style::default().fg(self.colors.muted))
                 .alignment(Alignment::Center);
             no_track.render(inner, buf);
+            return;
+        }
+
+        if let Some(station) = self.now_playing.radio_station.as_ref() {
+            let title = self
+                .now_playing
+                .radio_title
+                .as_deref()
+                .unwrap_or(&station.name);
+            let artist = self
+                .now_playing
+                .radio_artist
+                .as_deref()
+                .unwrap_or("Internet Radio");
+            let subtitle = station.home_page_url.as_deref().unwrap_or(&station.name);
+            let quality = build_quality_string(self.now_playing);
+
+            if inner.height >= 5 {
+                let chunks = Layout::vertical([
+                    Constraint::Length(1), // Artist
+                    Constraint::Length(1), // Station/subtitle
+                    Constraint::Length(1), // Title
+                    Constraint::Length(1), // Quality
+                    Constraint::Length(1), // Elapsed
+                ])
+                .split(inner);
+
+                Paragraph::new(Line::from(vec![Span::styled(
+                    artist,
+                    Style::default().fg(self.colors.artist),
+                )]))
+                .alignment(Alignment::Center)
+                .render(chunks[0], buf);
+
+                Paragraph::new(Line::from(vec![Span::styled(
+                    subtitle,
+                    Style::default().fg(self.colors.album),
+                )]))
+                .alignment(Alignment::Center)
+                .render(chunks[1], buf);
+
+                Paragraph::new(Line::from(vec![Span::styled(
+                    title,
+                    Style::default()
+                        .fg(self.colors.highlight_fg)
+                        .add_modifier(Modifier::BOLD),
+                )]))
+                .alignment(Alignment::Center)
+                .render(chunks[2], buf);
+
+                if !quality.is_empty() {
+                    Paragraph::new(Line::from(vec![Span::styled(
+                        quality,
+                        Style::default().fg(self.colors.muted),
+                    )]))
+                    .alignment(Alignment::Center)
+                    .render(chunks[3], buf);
+                }
+
+                render_elapsed(chunks[4], buf, self.now_playing, &self.colors);
+            } else if inner.height >= 3 {
+                let chunks = Layout::vertical([
+                    Constraint::Length(1), // Title - Artist
+                    Constraint::Length(1), // Station / Quality
+                    Constraint::Length(1), // Elapsed
+                ])
+                .split(inner);
+
+                let line1 = Line::from(vec![
+                    Span::styled(
+                        title,
+                        Style::default()
+                            .fg(self.colors.highlight_fg)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" - ", Style::default().fg(self.colors.muted)),
+                    Span::styled(artist, Style::default().fg(self.colors.artist)),
+                ]);
+                Paragraph::new(line1)
+                    .alignment(Alignment::Center)
+                    .render(chunks[0], buf);
+
+                let line2_text = if quality.is_empty() {
+                    subtitle
+                } else {
+                    &quality
+                };
+                Paragraph::new(Line::from(vec![Span::styled(
+                    line2_text,
+                    Style::default().fg(self.colors.album),
+                )]))
+                .alignment(Alignment::Center)
+                .render(chunks[1], buf);
+
+                render_elapsed(chunks[2], buf, self.now_playing, &self.colors);
+            } else {
+                let chunks =
+                    Layout::vertical([Constraint::Length(1), Constraint::Length(1)]).split(inner);
+                Paragraph::new(Line::from(vec![Span::styled(
+                    title,
+                    Style::default().fg(self.colors.highlight_fg),
+                )]))
+                .alignment(Alignment::Center)
+                .render(chunks[0], buf);
+                render_elapsed(chunks[1], buf, self.now_playing, &self.colors);
+            }
+
             return;
         }
 
@@ -80,25 +187,7 @@ impl Widget for NowPlayingWidget<'_> {
         let title = song.title.clone();
 
         // Build quality string
-        let mut quality_parts = Vec::new();
-        if let Some(ref fmt) = self.now_playing.format {
-            quality_parts.push(fmt.to_string().to_uppercase());
-        }
-        if let Some(bits) = self.now_playing.bit_depth {
-            quality_parts.push(format!("{}-bit", bits));
-        }
-        if let Some(rate) = self.now_playing.sample_rate {
-            let khz = rate as f64 / 1000.0;
-            if khz == khz.floor() {
-                quality_parts.push(format!("{}kHz", khz as u32));
-            } else {
-                quality_parts.push(format!("{:.1}kHz", khz));
-            }
-        }
-        if let Some(ref channels) = self.now_playing.channels {
-            quality_parts.push(channels.to_string());
-        }
-        let quality = quality_parts.join(" │ ");
+        let quality = build_quality_string(self.now_playing);
 
         // Layout based on available height
         if inner.height >= 5 {
@@ -229,6 +318,39 @@ impl Widget for NowPlayingWidget<'_> {
             );
         }
     }
+}
+
+fn build_quality_string(now_playing: &NowPlaying) -> String {
+    let mut quality_parts = Vec::new();
+    if let Some(ref fmt) = now_playing.format {
+        quality_parts.push(fmt.to_string().to_uppercase());
+    }
+    if let Some(bits) = now_playing.bit_depth {
+        quality_parts.push(format!("{}-bit", bits));
+    }
+    if let Some(rate) = now_playing.sample_rate {
+        let khz = rate as f64 / 1000.0;
+        if khz == khz.floor() {
+            quality_parts.push(format!("{}kHz", khz as u32));
+        } else {
+            quality_parts.push(format!("{:.1}kHz", khz));
+        }
+    }
+    if let Some(ref channels) = now_playing.channels {
+        quality_parts.push(channels.to_string());
+    }
+    quality_parts.join(" │ ")
+}
+
+fn render_elapsed(area: Rect, buf: &mut Buffer, now_playing: &NowPlaying, colors: &ThemeColors) {
+    if area.width < 5 {
+        return;
+    }
+
+    let elapsed = now_playing.format_position();
+    let text = format!("Live │ {}", elapsed);
+    let start_x = area.x + (area.width.saturating_sub(text.len() as u16)) / 2;
+    buf.set_string(start_x, area.y, text, Style::default().fg(colors.muted));
 }
 
 /// Render a simple progress bar


### PR DESCRIPTION
## Summary
- Add Radio tab for Subsonic/Navidrome internet radio stations
- Play station `streamUrl` directly with live mpv metadata fallback
- Add Radio UI/input/mouse support, MPRIS metadata, docs, and tests

## Verification
- cargo test
