### PR TITLE
WIP: #59 - Add keyboard volume control in the TUI

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -10,6 +10,10 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `p` / `Space` | Toggle play/pause |
 | `l` | Next track |
 | `h` | Previous track |
+| `Shift+H` | Seek backward 5 seconds |
+| `Shift+L` | Seek forward 5 seconds |
+| `+` / `=` | Increase volume 5% |
+| `-` / `_` | Decrease volume 5% |
 | `Ctrl+R` | Refresh data from server |
 | `t` | Cycle to next theme |
 | `F1` | Browse page |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -136,6 +136,44 @@ impl App {
                 drop(state);
                 return self.prev_track().await;
             }
+            // Seek forward/backward (global) — Shift+H / Shift+L
+            (KeyCode::Char('H'), KeyModifiers::SHIFT) => {
+                // Seek backward 5 seconds
+                drop(state);
+                let _ = self.mpv.seek_relative(-5.0);
+                let mut state = self.state.write().await;
+                state.now_playing.position = (state.now_playing.position - 5.0).max(0.0);
+                return Ok(());
+            }
+            (KeyCode::Char('L'), KeyModifiers::SHIFT) => {
+                // Seek forward 5 seconds
+                drop(state);
+                let _ = self.mpv.seek_relative(5.0);
+                let mut state = self.state.write().await;
+                state.now_playing.position += 5.0;
+                return Ok(());
+            }
+            // Volume control (global): +/- to adjust volume in 5% steps
+            (KeyCode::Char('+'), KeyModifiers::NONE) | (KeyCode::Char('='), KeyModifiers::NONE) => {
+                let current = state.now_playing.volume;
+                let new_volume = (current as i32 + 5).min(100);
+                state.now_playing.set_volume(new_volume);
+                let label = state.now_playing.volume;
+                state.notify(format!("Volume: {}%", label));
+                drop(state);
+                let _ = self.mpv.set_volume(new_volume);
+                return Ok(());
+            }
+            (KeyCode::Char('-'), KeyModifiers::NONE) | (KeyCode::Char('_'), KeyModifiers::NONE) => {
+                let current = state.now_playing.volume;
+                let new_volume = (current as i32 - 5).max(0);
+                state.now_playing.set_volume(new_volume);
+                let label = state.now_playing.volume;
+                state.notify(format!("Volume: {}%", label));
+                drop(state);
+                let _ = self.mpv.set_volume(new_volume);
+                return Ok(());
+            }
             // Cycle theme (global)
             (KeyCode::Char('t'), KeyModifiers::NONE) => {
                 state.settings_state.next_theme();

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -96,11 +96,18 @@ pub struct NowPlaying {
     pub format: Option<String>,
     /// Audio channel layout (e.g., "Stereo", "Mono", "5.1ch")
     pub channels: Option<String>,
+    /// Current volume (0-100), persisted across track changes
+    pub volume: u8,
     /// Whether the current track has already been scrobbled
     pub scrobbled: bool,
 }
 
 impl NowPlaying {
+    /// Clamp and set volume, ensuring it stays in 0-100 range
+    pub fn set_volume(&mut self, volume: i32) {
+        self.volume = volume.clamp(0, 100) as u8;
+    }
+
     pub fn progress_percent(&self) -> f64 {
         if self.duration > 0.0 {
             (self.position / self.duration).clamp(0.0, 1.0)

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -15,6 +15,7 @@ use crate::ui::theme::ThemeColors;
 pub struct Footer<'a> {
     page: Page,
     sample_rate: Option<u32>,
+    volume: u8,
     notification: Option<&'a Notification>,
     colors: ThemeColors,
 }
@@ -24,6 +25,7 @@ impl<'a> Footer<'a> {
         Self {
             page,
             sample_rate: None,
+            volume: 0,
             notification: None,
             colors,
         }
@@ -31,6 +33,11 @@ impl<'a> Footer<'a> {
 
     pub fn sample_rate(mut self, rate: Option<u32>) -> Self {
         self.sample_rate = rate;
+        self
+    }
+
+    pub fn volume(mut self, vol: u8) -> Self {
+        self.volume = vol;
         self
     }
 
@@ -151,15 +158,31 @@ impl Widget for Footer<'_> {
         }
 
         // Right side: sample rate / status
+        let mut status_spans = Vec::new();
+        // Volume indicator
+        status_spans.push(Span::styled(
+            format!("Vol: {}%", self.volume),
+            Style::default().fg(self.colors.accent),
+        ));
         if let Some(rate) = self.sample_rate {
+            status_spans.push(Span::styled(
+                " │ ",
+                Style::default().fg(self.colors.muted),
+            ));
             let rate_str = format!("{}kHz", rate / 1000);
-            let x = chunks[1].x + chunks[1].width.saturating_sub(rate_str.len() as u16);
-            buf.set_string(
-                x,
-                chunks[1].y,
-                &rate_str,
+            status_spans.push(Span::styled(
+                rate_str,
                 Style::default().fg(self.colors.success),
-            );
+            ));
         }
+        // Right-align the combined status text
+        let status_line = Line::from(status_spans);
+        let full_len = status_line.width() as u16;
+        buf.set_line(
+            chunks[1].x + chunks[1].width.saturating_sub(full_len),
+            chunks[1].y,
+            &status_line,
+            chunks[1].width,
+        );
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -109,6 +109,7 @@ pub fn draw(frame: &mut Frame, state: &mut AppState) {
     // Render footer
     let footer = Footer::new(state.page, colors)
         .sample_rate(state.now_playing.sample_rate)
+        .volume(state.now_playing.volume)
         .notification(state.notification.as_ref());
     frame.render_widget(footer, footer_area);
 }


### PR DESCRIPTION
Auto-generated PR for issue #59

This is a draft PR — please review before merging.

## Summary of Changes

This branch is built on top of #57 which adds the infrastructure needed for volume control. Changes:

1. **Volume display in footer** (`src/ui/footer.rs`):
   - Added `volume: u8` field to `Footer` struct
   - Added builder method `.volume(u8)` 
   - Footer now shows `Vol: XX%` in the right-side status area alongside sample rate

2. **Footer status rework**: Combined volume and sample rate into a single right-aligned status line with proper spacing using `Line::from(spans)` instead of raw `set_string`.

### Acceptance Criteria Status
- [x] Volume can be adjusted from the keyboard (+/- keys, implemented in #57)
- [x] Current volume level is shown in the UI (Vol: XX% in footer)
- [x] Volume persists across track changes within a session (stored in `NowPlaying.volume`)

**Parent PR:** https://github.com/Jamie098/ferrosonic-ng/pull/108