### PR TITLE
WIP: #57 - Add keyboard shortcuts for seek forward/backward

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -10,6 +10,8 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `p` / `Space` | Toggle play/pause |
 | `l` | Next track |
 | `h` | Previous track |
+| `H` | Seek backward 5 seconds |
+| `L` | Seek forward 5 seconds |
 | `Ctrl+R` | Refresh data from server |
 | `t` | Cycle to next theme |
 | `F1` | Browse page |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -136,6 +136,16 @@ impl App {
                 drop(state);
                 return self.prev_track().await;
             }
+            (KeyCode::Char('H'), KeyModifiers::NONE) => {
+                // Seek backward 5 seconds
+                let _ = self.mpv.seek_relative(-5.0);
+                return Ok(());
+            }
+            (KeyCode::Char('L'), KeyModifiers::NONE) => {
+                // Seek forward 5 seconds
+                let _ = self.mpv.seek_relative(5.0);
+                return Ok(());
+            }
             // Cycle theme (global)
             (KeyCode::Char('t'), KeyModifiers::NONE) => {
                 state.settings_state.next_theme();


### PR DESCRIPTION
Auto-generated PR for issue #57

Adds global keyboard shortcuts for seeking forward and backward in the current track:
- `H` (Shift+h) – Seek backward 5 seconds
- `L` (Shift+l) – Seek forward 5 seconds

Keybindings are documented in `docs/keybindings.md`.

This is a draft PR — please review before merging.