### PR TITLE
WIP: #57 - Add keyboard shortcuts for seek forward/backward

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -10,6 +10,8 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `p` / `Space` | Toggle play/pause |
 | `l` | Next track |
 | `h` | Previous track |
+| `←` / `Shift+H` | Seek backward 5 seconds |
+| `→` / `Shift+L` | Seek forward 5 seconds |
 | `Ctrl+R` | Refresh data from server |
 | `t` | Cycle to next theme |
 | `F1` | Browse page |

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -136,6 +136,16 @@ impl App {
                 drop(state);
                 return self.prev_track().await;
             }
+            // Seek backward (← or Shift+H)
+            (KeyCode::Left, _) | (KeyCode::Char('h'), KeyModifiers::SHIFT) => {
+                let _ = self.mpv.seek_relative(-5.0);
+                return Ok(());
+            }
+            // Seek forward (→ or Shift+L)
+            (KeyCode::Right, _) | (KeyCode::Char('l'), KeyModifiers::SHIFT) => {
+                let _ = self.mpv.seek_relative(5.0);
+                return Ok(());
+            }
             // Cycle theme (global)
             (KeyCode::Char('t'), KeyModifiers::NONE) => {
                 state.settings_state.next_theme();


### PR DESCRIPTION
Auto-generated PR for issue #57

This is a draft PR — please review before merging.

**Changes:**
- Added global keybindings for seeking forward/backward:
  - `←` / `Shift+H` → seek backward 5 seconds
  - `→` / `Shift+L` → seek forward 5 seconds
- Updated `docs/keybindings.md` with new keybindings

**Acceptance Criteria:**
- [x] At least two seek keybindings (forward and backward) work from any page
- [x] Seek bindings are documented in `docs/keybindings.md`