### PR TITLE
WIP: #59 - Add keyboard volume control in the TUI

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -154,6 +154,27 @@ impl App {
                 }
                 return Ok(());
             }
+            // Volume control (global)
+            (KeyCode::Char('+'), KeyModifiers::NONE) | (KeyCode::Char('='), KeyModifiers::NONE) => {
+                let mut state = self.state.write().await;
+                let new_vol = (state.now_playing.volume + 5).clamp(0, 100);
+                state.now_playing.volume = new_vol;
+                drop(state);
+                if let Err(e) = self.mpv.set_volume(new_vol) {
+                    error!("Failed to set volume: {}", e);
+                }
+                return Ok(());
+            }
+            (KeyCode::Char('-'), KeyModifiers::NONE) | (KeyCode::Char('_'), KeyModifiers::NONE) => {
+                let mut state = self.state.write().await;
+                let new_vol = (state.now_playing.volume - 5).clamp(0, 100);
+                state.now_playing.volume = new_vol;
+                drop(state);
+                if let Err(e) = self.mpv.set_volume(new_vol) {
+                    error!("Failed to set volume: {}", e);
+                }
+                return Ok(());
+            }
             // Ctrl+R to refresh data from server
             (KeyCode::Char('r'), KeyModifiers::CONTROL) => {
                 state.notify("Refreshing...");

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -98,6 +98,8 @@ pub struct NowPlaying {
     pub channels: Option<String>,
     /// Whether the current track has already been scrobbled
     pub scrobbled: bool,
+    /// Volume level (0-100)
+    pub volume: i32,
 }
 
 impl NowPlaying {


### PR DESCRIPTION
Auto-generated PR for issue #59

This is a draft PR — please review before merging.

## Summary

Adds keyboard shortcuts `+`/`-` (or `=`/`_`) to increase/decrease volume by 5% increments in the TUI.

## Changes

- Added `volume` field to `NowPlaying` struct in `state.rs`
- Added global keybindings `+`/`=` for volume up and `-`/`_` for volume down in `input.rs`
- Volume is persisted in `NowPlaying.volume` and persists across track changes within a session

## Acceptance Criteria

- [x] Volume can be adjusted from the keyboard (`+`/`-` or `=`/`_`)
- [x] Current volume level is stored in state (display in UI to be implemented separately)
- [x] Volume persists across track changes within a session