### PR TITLE
#121 - Unbounded vector growth in browse data with no pruning

### DIFF
--- a/src/app/input_artists.rs
+++ b/src/app/input_artists.rs
@@ -373,6 +373,11 @@ impl App {
                                                 Ok((_artist, albums)) => {
                                                     let mut state = self.state.write().await;
                                                     let count = albums.len();
+                                                    if state.artists.albums_cache.len()
+                                                        >= ArtistsState::MAX_ALBUMS_CACHE
+                                                    {
+                                                        state.artists.albums_cache.clear();
+                                                    }
                                                     state
                                                         .artists
                                                         .albums_cache

--- a/src/app/mouse_artists.rs
+++ b/src/app/mouse_artists.rs
@@ -52,6 +52,11 @@ impl App {
                                         Ok((_artist, albums)) => {
                                             let mut state = self.state.write().await;
                                             let count = albums.len();
+                                            if state.artists.albums_cache.len()
+                                                >= ArtistsState::MAX_ALBUMS_CACHE
+                                            {
+                                                state.artists.albums_cache.clear();
+                                            }
                                             state
                                                 .artists
                                                 .albums_cache

--- a/src/app/repo.rs
+++ b/src/app/repo.rs
@@ -7,6 +7,12 @@ impl App {
     /// Page size used by the Albums view (max allowed by getAlbumList2).
     const ALL_ALBUMS_PAGE_SIZE: usize = 500;
 
+    /// Maximum number of songs to keep in the All-songs view to prevent unbounded growth.
+    const MAX_BROWSE_SONGS: usize = 5000;
+
+    /// Maximum number of albums to keep in the Albums view to prevent unbounded growth.
+    const MAX_BROWSE_ALBUMS: usize = 5000;
+
     /// Fetch the next page of songs for the "All" view via `search3`.
     ///
     /// When `append` is `false` the song list is replaced (used on first load
@@ -35,6 +41,9 @@ impl App {
 
                     if append {
                         state.browse.songs.extend(songs);
+                        if state.browse.songs.len() > Self::MAX_BROWSE_SONGS {
+                            state.browse.songs.truncate(Self::MAX_BROWSE_SONGS);
+                        }
                     } else {
                         state.browse.songs = songs;
                         state.browse.selected_index = if fetched > 0 { Some(0) } else { None };
@@ -120,6 +129,9 @@ impl App {
                     let scroll = state.browse.album_scroll_offset;
                     if append {
                         state.browse.backing_albums.extend(albums);
+                        if state.browse.backing_albums.len() > Self::MAX_BROWSE_ALBUMS {
+                            state.browse.backing_albums.truncate(Self::MAX_BROWSE_ALBUMS);
+                        }
                     } else {
                         state.browse.backing_albums = albums;
                     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -272,6 +272,11 @@ pub struct ArtistsState {
     pub song_scroll_offset: usize,
 }
 
+impl ArtistsState {
+    /// Maximum number of artist album caches to retain.
+    pub const MAX_ALBUMS_CACHE: usize = 100;
+}
+
 /// Queue page state
 #[derive(Debug, Clone, Default)]
 pub struct QueueState {


### PR DESCRIPTION
Auto-generated PR for issue #121

Fixes #121

This is a draft PR — please review before merging.