### PR TITLE
Queue auto-extend from Browse All and follow-playback scrolling

### DIFF
--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -211,6 +211,10 @@ impl App {
                             let mut state = self.state.write().await;
                             state.queue.clear();
                             state.queue.extend(songs);
+                            state.queue_auto_extend = false;
+                            state.queue_source_offset = 0;
+                            state.queue_source_has_more = false;
+                            state.queue_source_filter.clear();
                             state.notify(format!("Playing: {} ({} songs)", album_name, count));
                             drop(state);
                             self.save_queue_sync();
@@ -240,6 +244,20 @@ impl App {
                 state.queue.clear();
                 let songs = state.browse.songs.clone();
                 state.queue.extend(songs);
+
+                // Enable auto-extension if this is the "All" view with more pages
+                if state.browse.selected_option == Some(SongOption::All) {
+                    state.queue_auto_extend = true;
+                    state.queue_source_offset = state.browse.all_songs_offset;
+                    state.queue_source_has_more = state.browse.all_songs_has_more;
+                    state.queue_source_filter = state.browse.filter.clone();
+                } else {
+                    state.queue_auto_extend = false;
+                    state.queue_source_offset = 0;
+                    state.queue_source_has_more = false;
+                    state.queue_source_filter.clear();
+                }
+
                 drop(state);
                 self.save_queue_sync();
 

--- a/src/app/input_queue.rs
+++ b/src/app/input_queue.rs
@@ -132,6 +132,10 @@ impl App {
                 } else {
                     state.queue.shuffle(&mut rng);
                 }
+                state.queue_auto_extend = false;
+                state.queue_source_offset = 0;
+                state.queue_source_has_more = false;
+                state.queue_source_filter.clear();
                 state.notify("Queue shuffled");
                 drop(state);
                 self.save_queue_sync();
@@ -143,6 +147,10 @@ impl App {
                         let removed = pos;
                         state.queue.drain(0..pos);
                         state.queue_position = Some(0);
+                        state.queue_auto_extend = false;
+                        state.queue_source_offset = 0;
+                        state.queue_source_has_more = false;
+                        state.queue_source_filter.clear();
                         // Adjust selection
                         if let Some(sel) = state.queue_state.selected {
                             if sel < pos {

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -42,7 +42,26 @@ impl App {
                     .unwrap_or(false);
                 drop(state);
 
-                if has_next && time_remaining > 0.0 && time_remaining < 2.0 {
+                if !has_next && time_remaining > 0.0 && time_remaining < 2.0 {
+                    self.maybe_extend_queue().await;
+                    // Re-check after possible extension
+                    let state = self.state.read().await;
+                    let has_next_now = state
+                        .queue_position
+                        .map(|p| p + 1 < state.queue.len())
+                        .unwrap_or(false);
+                    drop(state);
+
+                    if has_next_now {
+                        if let Ok(count) = self.mpv.get_playlist_count() {
+                            if count < 2 {
+                                info!("Near end of track with no preloaded next — advancing early");
+                                let _ = self.next_track().await;
+                                return;
+                            }
+                        }
+                    }
+                } else if has_next && time_remaining > 0.0 && time_remaining < 2.0 {
                     if let Ok(count) = self.mpv.get_playlist_count() {
                         if count < 2 {
                             info!("Near end of track with no preloaded next — advancing early");
@@ -58,10 +77,20 @@ impl App {
                 if count == 1 {
                     let state = self.state.read().await;
                     if let Some(pos) = state.queue_position {
-                        if pos + 1 < state.queue.len() {
+                        if pos + 1 >= state.queue.len() {
                             drop(state);
-                            debug!("Playlist count is 1, re-preloading next track");
-                            self.preload_next_track(pos).await;
+                            self.maybe_extend_queue().await;
+                        } else {
+                            drop(state);
+                        }
+                        // Re-check after possible extension
+                        let state = self.state.read().await;
+                        if let Some(pos) = state.queue_position {
+                            if pos + 1 < state.queue.len() {
+                                drop(state);
+                                debug!("Playlist count is 1, re-preloading next track");
+                                self.preload_next_track(pos).await;
+                            }
                         }
                     }
                 }
@@ -82,6 +111,7 @@ impl App {
                             // for gapless transitions (same album, same format)
                             let mut state = self.state.write().await;
                             state.queue_position = Some(next_pos);
+                            state.queue_state.selected = Some(next_pos);
                             if let Some(song) = state.queue.get(next_pos).cloned() {
                                 state.now_playing.song = Some(song.clone());
                                 state.now_playing.radio_station = None;
@@ -353,6 +383,22 @@ impl App {
 
         let next_pos = match current_pos {
             Some(pos) if pos + 1 < queue_len => pos + 1,
+            Some(pos) if pos + 1 >= queue_len => {
+                self.maybe_extend_queue().await;
+                let state = self.state.read().await;
+                let queue_len = state.queue.len();
+                drop(state);
+                if pos + 1 < queue_len {
+                    pos + 1
+                } else {
+                    info!("Reached end of queue");
+                    let _ = self.mpv.stop();
+                    let mut state = self.state.write().await;
+                    state.now_playing.state = PlaybackState::Stopped;
+                    state.now_playing.position = 0.0;
+                    return Ok(());
+                }
+            }
             _ => {
                 info!("Reached end of queue");
                 let _ = self.mpv.stop();
@@ -429,6 +475,7 @@ impl App {
         {
             let mut state = self.state.write().await;
             state.queue_position = Some(pos);
+            state.queue_state.selected = Some(pos);
             state.now_playing.song = Some(song.clone());
             state.now_playing.radio_station = None;
             state.now_playing.radio_title = None;
@@ -469,6 +516,10 @@ impl App {
             state.queue.clear();
             state.queue_position = None;
             state.queue_state.selected = None;
+            state.queue_auto_extend = false;
+            state.queue_source_offset = 0;
+            state.queue_source_has_more = false;
+            state.queue_source_filter.clear();
             state.now_playing.song = None;
             state.now_playing.radio_station = Some(station.clone());
             state.now_playing.radio_title = None;
@@ -560,10 +611,94 @@ impl App {
         state.now_playing.channels = None;
         state.queue.clear();
         state.queue_position = None;
+        state.queue_state.selected = None;
+        state.queue_auto_extend = false;
+        state.queue_source_offset = 0;
+        state.queue_source_has_more = false;
+        state.queue_source_filter.clear();
         drop(state);
 
         self.save_queue().await;
         Ok(())
+    }
+
+    /// If the queue was created from Browse → All Songs and we're near the end,
+    /// fetch the next page and append it to the queue.
+    async fn maybe_extend_queue(&mut self) {
+        let (_should_extend, offset, filter) = {
+            let state = self.state.read().await;
+            if !state.queue_auto_extend {
+                return;
+            }
+            if state.browse.all_songs_loading {
+                return;
+            }
+            if !state.queue_source_has_more {
+                return;
+            }
+
+            let pos = state.queue_position.unwrap_or(0);
+            if pos + INFINITE_SCROLL_LOOKAHEAD < state.queue.len() {
+                return;
+            }
+
+            // Verify the queue still starts with browse.songs so we don't
+            // extend a queue that has been replaced from another source.
+            let browse_len = state.browse.songs.len();
+            if browse_len > 0
+                && state.queue.len() >= browse_len
+                && state
+                    .queue
+                    .iter()
+                    .zip(state.browse.songs.iter())
+                    .all(|(q, b)| q.id == b.id)
+            {
+                (
+                    true,
+                    state.queue_source_offset,
+                    state.queue_source_filter.clone(),
+                )
+            } else {
+                return;
+            }
+        };
+
+        if let Some(ref client) = self.subsonic {
+            {
+                let mut state = self.state.write().await;
+                state.browse.all_songs_loading = true;
+            }
+
+            // Must match the page size used by get_all_songs
+            const PAGE_SIZE: usize = 50;
+            match client.search_songs(&filter, offset, PAGE_SIZE).await {
+                Ok(songs) => {
+                    let fetched = songs.len();
+                    let has_more = fetched == PAGE_SIZE;
+
+                    let mut state = self.state.write().await;
+                    state.queue.extend(songs);
+                    state.queue_source_offset = offset + fetched;
+                    state.queue_source_has_more = has_more;
+                    state.browse.all_songs_loading = false;
+                    drop(state);
+                    self.save_queue_sync();
+
+                    info!(
+                        "Extended queue by {} songs (offset now {})",
+                        fetched,
+                        offset + fetched
+                    );
+                }
+                Err(e) => {
+                    error!("Failed to extend queue: {}", e);
+                    let mut state = self.state.write().await;
+                    state.browse.all_songs_loading = false;
+                    state.queue_source_has_more = false;
+                    state.notify_error(format!("Failed to extend queue: {}", e));
+                }
+            }
+        }
     }
 
     async fn notify_track_change(&mut self, pos: usize) {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -472,6 +472,14 @@ pub struct AppState {
     pub server_state: ServerState,
     /// Settings page state (app preferences)
     pub settings_state: SettingsState,
+    /// Whether the queue can auto-extend from Browse → All Songs
+    pub queue_auto_extend: bool,
+    /// Pagination offset for queue auto-extension
+    pub queue_source_offset: usize,
+    /// Whether more songs are available for queue auto-extension
+    pub queue_source_has_more: bool,
+    /// Filter used when queue was created from Browse → All Songs
+    pub queue_source_filter: String,
     /// Current notification
     pub notification: Option<Notification>,
     /// Whether the app should quit

--- a/src/ui/pages/queue.rs
+++ b/src/ui/pages/queue.rs
@@ -120,6 +120,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState, mutations: &mut R
         .highlight_symbol("▸ ");
 
     let mut list_state = ListState::default();
+    *list_state.offset_mut() = state.queue_state.scroll_offset;
     list_state.select(state.queue_state.selected);
 
     frame.render_stateful_widget(list, area, &mut list_state);


### PR DESCRIPTION
## Problem

When playing from **Browse → Songs → All**, the queue is a static snapshot of whatever pages were pre-loaded. If the user keeps pressing `l` (next) or lets playback advance gaplessly, the queue runs out even though more songs exist on the server.

Additionally, the Queue view never auto-scrolls to the currently playing track — the user has to manually navigate to see what is playing.

## Solution

### 1. Queue auto-extension (lazy pagination)
When the queue was created from Browse → All, the app now remembers the stream source (filter, offset, has-more flag). As playback approaches the end of the queue (within `INFINITE_SCROLL_LOOKAHEAD` tracks), it fetches the next page from the server and appends it.

Triggered proactively in three places:
- `next_track()` — when the user presses `l` at the end of the queue
- `update_playback_info()` — when the current track is <2s from ending with no next track preloaded
- Re-preload check — after a gapless transition when the playlist count is 1

Safety: `maybe_extend_queue()` verifies the queue still starts with `browse.songs` before extending, preventing accidental extension after the user switches to a different source (Albums, Artists, Playlists).

### 2. Queue follows playback (auto-scroll)
`queue_state.selected` is now set to the playing track whenever playback advances: `next_track()`, gapless transitions, and `play_queue_position()`. The Queue page uses `selected` for its scroll offset, so it automatically scrolls to keep the playing track visible.

## Files changed
- `src/app/state.rs` — 4 new queue-source fields
- `src/app/playback.rs` — `maybe_extend_queue()`, queue-follow, reset on stop/radio
- `src/app/input_browse.rs` — set source on All-Songs Enter, reset on Album Enter
- `src/app/input_queue.rs` — reset source on shuffle and clear-history

## Testing
- `cargo check` ✓
- `cargo clippy` ✓ (35 pre-existing warnings)
- `cargo test` ✓ (48 passed)