### PR TITLE
Release 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,11 @@ jobs:
             target
           key: ${{ runner.os }}-1.88.0-cargo-test-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy --locked -- -D warnings
+
       - name: Run tests
         run: cargo test --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## 1.0.0 - 2026-05-11
+
+### Added
+
+- **Repeat / loop mode** - Cycle between Off, All, and One with the `r` key. Repeat All wraps the queue; Repeat One restarts the current track. MPRIS `LoopStatus` is fully wired.
+- **Keyboard volume control** - Adjust playback volume with `+` / `-` in 5% steps. Volume is displayed in the footer and persisted across sessions.
+- **Queue auto-extension** - When playing from Browse > All Songs, the queue automatically fetches the next page as you approach the end, preventing playback from stopping unexpectedly.
+- **Queue follows playback** - The Queue view now auto-scrolls to keep the currently playing track visible.
+- **Signal handling** - SIGINT and SIGTERM are caught for graceful shutdown, ensuring queue persistence, MPV cleanup, PipeWire rate restoration, and terminal recovery always run.
+
+### Fixed
+
+- **Clippy warnings** - All 30 clippy warnings resolved; CI now gates on `cargo clippy -- -D warnings` and `cargo fmt --check`.
+- **Cava temp path conflict** - Cava config now uses a PID-unique temp directory, preventing collisions when running multiple ferrosonic instances.
+- **Production unwrap calls** - Replaced remaining production `unwrap()` calls with safe error handling.
+- **PipeWire rate restore on shutdown** - The original sample rate is now always restored on exit, even when the process is terminated by a signal.
+
+### Changed
+
+- Queue persistence now saves and restores `repeat_mode` and `volume` alongside the queue and position.
+- Footer now displays repeat mode and volume status.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "ferrosonic"
-version = "0.7.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrosonic"
-version = "0.7.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.70"
 description = "A terminal-based Subsonic music client with bit-perfect audio playback"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Ferrosonic-ng is a continuation of the original [ferrosonic](https://github.com/
 - **Bit-perfect audio** — Automatic PipeWire sample rate switching to match source material (44.1kHz, 48kHz, 96kHz, 192kHz, etc.), with the original rate restored on exit
 - **Gapless playback** — Next track is pre-loaded into mpv's internal playlist for seamless transitions
 - **MPRIS2 integration** — Full desktop media controls (play, pause, stop, next, previous, seek)
+- **Repeat mode** — Cycle between Off, All, and One-track repeat
+- **Volume control** — Adjust playback volume with `+`/`−` keys, persisted across sessions
 - **Artist/album browser** — Tree-based navigation with expandable artists, album listings, and artist filtering
 - **Browse page** — Browse and search all, starred and random songs/albums from your server
 - **Playlists & queue management** — Browse server playlists, add/remove/reorder/shuffle queue, clear history
-- **Queue persistence** — Automatically save and restore your play queue and current position on launch
+- **Queue persistence** — Automatically save and restore your play queue, position, repeat mode, and volume on launch
 - **Internet radio** — Browse and play Navidrome/Subsonic radio stations with live stream metadata when available
 - **Audio quality display** — Real-time sample rate, bit depth, codec, and channel layout
 - **Audio visualizer** — Integrated [cava](https://github.com/karlstav/cava) visualizer with theme-matched gradient colors

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -12,6 +12,9 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `h` | Previous track |
 | `shift + h` | Seek backward 5 seconds |
 | `shift + l` | Seek forward 5 seconds |
+| `r` | Cycle repeat mode (Off / All / One) |
+| `+` / `=` | Volume up |
+| `-` | Volume down |
 | `Ctrl+R` | Refresh data from server |
 | `t` | Cycle to next theme |
 | `F1` | Browse page |
@@ -22,16 +25,21 @@ Ferrosonic is fully keyboard-driven. Vim-style `j`/`k` navigation is available a
 | `F6` | Server configuration page |
 | `F7` | Settings page |
 
-## Songs Page (F1)
+## Browse Page (F1)
 
 | Key | Action |
 |---|---|
-| `Tab` | Switch focus between song options and song list |
+| `Tab` | Switch focus between options pane and content list |
 | `Up` / `k` | Move selection up |
 | `Down` / `j` | Move selection down |
-| `Enter` | Play selected song (queues all visible songs and starts from selection) |
+| `Left` / `Right` | Switch between Songs and Albums tabs |
+| `/` | Activate filter/search |
+| `Enter` | Play selected song or album |
+| `e` | Add selected item to end of queue |
+| `n` | Add selected item as next in queue |
+| `f` | Star / un-star selected song or album |
 
-The Songs page has two modes selectable from the options pane: **Starred** (your favourited songs) and **Random** (a random selection from the server).
+The Browse page has three options in the left pane: **All** (paginated server search), **Starred** (your favourited songs/albums), and **Random** (a random selection from the server).
 
 ## Artists Page (F2)
 

--- a/src/app/cava.rs
+++ b/src/app/cava.rs
@@ -55,7 +55,13 @@ impl App {
         let slave_stdout = unsafe { std::fs::File::from_raw_fd(slave) };
         let slave_stdin = unsafe { std::fs::File::from_raw_fd(slave_stdin_fd) };
         let slave_stderr = unsafe { std::fs::File::from_raw_fd(slave_stderr_fd) };
-        let config_path = std::env::temp_dir().join("ferrosonic-cava.conf");
+        let config_path = std::env::temp_dir()
+            .join(format!("ferrosonic-cava-{}", std::process::id()))
+            .join("cava.conf");
+        // Ensure parent directory exists
+        if let Some(parent) = config_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
         if let Err(e) = std::fs::write(
             &config_path,
             generate_cava_config(cava_gradient, cava_horizontal_gradient),
@@ -63,6 +69,7 @@ impl App {
             error!("Failed to write cava config: {}", e);
             return;
         }
+        self.cava_config_path = Some(config_path.clone());
         let mut cmd = std::process::Command::new("cava");
         cmd.arg("-p").arg(&config_path);
         cmd.stdout(std::process::Stdio::from(slave_stdout))
@@ -110,6 +117,13 @@ impl App {
         self.cava_process = None;
         self.cava_pty_master = None;
         self.cava_parser = None;
+        if let Some(ref path) = self.cava_config_path {
+            let _ = std::fs::remove_file(path);
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::remove_dir(parent);
+            }
+        }
+        self.cava_config_path = None;
     }
 
     /// Read cava pty output and snapshot screen to state

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -72,7 +72,7 @@ impl App {
             (KeyCode::F(1), _) => {
                 state.page = Page::Browse;
                 let on_starred = state.browse.selected_option == Some(SongOption::Starred);
-                let browse_tab = state.browse.browse_tab.clone();
+                let browse_tab = state.browse.browse_tab;
                 let refresh_songs = on_starred
                     && browse_tab == BrowseTab::Songs
                     && state.browse.starred_songs_dirty;
@@ -146,6 +146,37 @@ impl App {
             (KeyCode::Char('L'), KeyModifiers::SHIFT) => {
                 drop(state);
                 let _ = self.mpv.seek_relative(5.0);
+                return Ok(());
+            }
+            // Cycle repeat mode (global)
+            (KeyCode::Char('r'), KeyModifiers::NONE) => {
+                let next = state.repeat_mode.next();
+                state.repeat_mode = next;
+                state.notify(format!("Repeat: {}", next.label()));
+                drop(state);
+                self.save_queue_sync();
+                return Ok(());
+            }
+            // Volume up
+            (KeyCode::Char('+'), KeyModifiers::NONE)
+            | (KeyCode::Char('='), KeyModifiers::NONE)
+            | (KeyCode::Char('+'), KeyModifiers::SHIFT) => {
+                let new_vol = (state.volume as i16 + 5).clamp(0, 100) as u8;
+                state.volume = new_vol;
+                drop(state);
+                let _ = self.mpv.set_volume(new_vol as i32);
+                self.save_queue_sync();
+                return Ok(());
+            }
+            // Volume down
+            (KeyCode::Char('-'), KeyModifiers::NONE)
+            | (KeyCode::Char('-'), KeyModifiers::SHIFT)
+            | (KeyCode::Char('_'), KeyModifiers::SHIFT) => {
+                let new_vol = (state.volume as i16 - 5).clamp(0, 100) as u8;
+                state.volume = new_vol;
+                drop(state);
+                let _ = self.mpv.set_volume(new_vol as i32);
+                self.save_queue_sync();
                 return Ok(());
             }
             // Cycle theme (global)

--- a/src/app/input_artists.rs
+++ b/src/app/input_artists.rs
@@ -51,15 +51,14 @@ impl App {
             KeyCode::Left => {
                 state.artists.focus = 0;
             }
-            KeyCode::Right => {
+            KeyCode::Right
                 // Move focus to songs (right pane)
-                if !state.artists.songs.is_empty() {
+                if !state.artists.songs.is_empty() => {
                     state.artists.focus = 1;
                     if state.artists.selected_song.is_none() {
                         state.artists.selected_song = Some(0);
                     }
                 }
-            }
             KeyCode::Up | KeyCode::Char('k') => {
                 if state.artists.focus == 0 {
                     // Tree navigation
@@ -146,8 +145,8 @@ impl App {
                     }
                 }
             }
-            KeyCode::Char('s') => {
-                if state.artists.focus == 0 {
+            KeyCode::Char('s')
+                if state.artists.focus == 0 => {
                     let tree_items = build_tree_items(&state);
                     if let Some(idx) = state.artists.selected_index {
                         if let Some(item) = tree_items.get(idx) {
@@ -166,7 +165,7 @@ impl App {
                                             Ok((_artist, albums)) => {
                                                 let mut artists_songs: Vec<_> = Vec::new();
 
-                                                for (_i, album) in albums.into_iter().enumerate() {
+                                                for album in albums.into_iter() {
                                                     match client.get_album(&album.id).await {
                                                         Ok((_album, songs)) => {
                                                             artists_songs.extend(songs);
@@ -230,7 +229,7 @@ impl App {
                                                     return Ok(());
                                                 }
 
-                                                let mut shuffled_songs: Vec<_> = Vec::from(songs);
+                                                let mut shuffled_songs: Vec<_> = songs;
                                                 shuffled_songs.shuffle(&mut thread_rng());
 
                                                 let mut state = self.state.write().await;
@@ -258,7 +257,6 @@ impl App {
                         }
                     }
                 }
-            }
             KeyCode::Char('f') => {
                 if state.artists.focus == 0 {
                     let tree_items = build_tree_items(&state);
@@ -467,11 +465,10 @@ impl App {
                     }
                 }
             }
-            KeyCode::Backspace => {
-                if state.artists.focus == 1 {
+            KeyCode::Backspace
+                if state.artists.focus == 1 => {
                     state.artists.focus = 0;
                 }
-            }
             KeyCode::Char('e') => {
                 if state.artists.focus == 1 {
                     if let Some(idx) = state.artists.selected_song {

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -21,8 +21,8 @@ impl App {
 
         match key.code {
             // Left/Right: switch between Songs and Albums
-            KeyCode::Left => {
-                if state.browse.browse_tab == BrowseTab::Albums {
+            KeyCode::Left
+                if state.browse.browse_tab == BrowseTab::Albums => {
                     state.browse.browse_tab = BrowseTab::Songs;
                     state.browse.filter.clear();
                     state.browse.focus = 0;
@@ -34,9 +34,8 @@ impl App {
                     self.load_song_option(selected_option.unwrap_or(SongOption::All))
                         .await;
                 }
-            }
-            KeyCode::Right => {
-                if state.browse.browse_tab == BrowseTab::Songs {
+            KeyCode::Right
+                if state.browse.browse_tab == BrowseTab::Songs => {
                     state.browse.browse_tab = BrowseTab::Albums;
                     state.browse.filter.clear();
                     state.browse.focus = 0;
@@ -48,7 +47,6 @@ impl App {
                     self.load_album_option(selected_option.unwrap_or(SongOption::All))
                         .await;
                 }
-            }
 
             // Activate filter
             KeyCode::Char('/') => {
@@ -73,7 +71,7 @@ impl App {
                     state.browse.selected_option = Some(opt.clone());
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
-                    let tab = state.browse.browse_tab.clone();
+                    let tab = state.browse.browse_tab;
                     drop(state);
                     match tab {
                         BrowseTab::Songs => self.load_song_option(opt).await,
@@ -94,7 +92,7 @@ impl App {
                     state.browse.selected_option = Some(opt.clone());
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
-                    let tab = state.browse.browse_tab.clone();
+                    let tab = state.browse.browse_tab;
                     drop(state);
                     match tab {
                         BrowseTab::Songs => self.load_song_option(opt).await,
@@ -505,7 +503,7 @@ impl App {
                     let mut state = self.state.write().await;
                     state.browse.filter.pop();
                     (
-                        state.browse.browse_tab.clone(),
+                        state.browse.browse_tab,
                         state.browse.selected_option.clone(),
                     )
                 };
@@ -516,7 +514,7 @@ impl App {
                     let mut state = self.state.write().await;
                     state.browse.filter.push(c);
                     (
-                        state.browse.browse_tab.clone(),
+                        state.browse.browse_tab,
                         state.browse.selected_option.clone(),
                     )
                 };
@@ -547,7 +545,7 @@ impl App {
         let (tab, option) = {
             let state = self.state.read().await;
             (
-                state.browse.browse_tab.clone(),
+                state.browse.browse_tab,
                 state.browse.selected_option.clone(),
             )
         };
@@ -617,9 +615,7 @@ impl App {
             .selected_index
             .filter(|&idx| idx < state.browse.songs.len());
 
-        let Some(selected_song_idx) = selected_song_idx else {
-            return None;
-        };
+        let selected_song_idx = selected_song_idx?;
 
         let song = state.browse.songs[selected_song_idx].clone();
         Some(song)
@@ -634,9 +630,7 @@ impl App {
             .selected_album
             .filter(|&idx| idx < state.browse.albums.len());
 
-        let Some(selected_album_idx) = selected_album_idx else {
-            return None;
-        };
+        let selected_album_idx = selected_album_idx?;
 
         let album = state.browse.albums[selected_album_idx].clone();
         Some(album)

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -27,7 +27,7 @@ impl App {
                     state.browse.filter.clear();
                     state.browse.focus = 0;
 
-                    let selected_option = state.browse.selected_option.clone();
+                    let selected_option = state.browse.selected_option;
                     drop(state);
                     self.songs_filter_debounce = None;
 
@@ -40,7 +40,7 @@ impl App {
                     state.browse.filter.clear();
                     state.browse.focus = 0;
 
-                    let selected_option = state.browse.selected_option.clone();
+                    let selected_option = state.browse.selected_option;
                     drop(state);
                     self.songs_filter_debounce = None;
 
@@ -68,7 +68,7 @@ impl App {
                 };
 
                 if let Some(opt) = next {
-                    state.browse.selected_option = Some(opt.clone());
+                    state.browse.selected_option = Some(opt);
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
                     let tab = state.browse.browse_tab;
@@ -89,7 +89,7 @@ impl App {
                 };
 
                 if let Some(opt) = next {
-                    state.browse.selected_option = Some(opt.clone());
+                    state.browse.selected_option = Some(opt);
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
                     let tab = state.browse.browse_tab;
@@ -504,7 +504,7 @@ impl App {
                     state.browse.filter.pop();
                     (
                         state.browse.browse_tab,
-                        state.browse.selected_option.clone(),
+                        state.browse.selected_option,
                     )
                 };
                 self.apply_filter_for(tab, option).await;
@@ -515,7 +515,7 @@ impl App {
                     state.browse.filter.push(c);
                     (
                         state.browse.browse_tab,
-                        state.browse.selected_option.clone(),
+                        state.browse.selected_option,
                     )
                 };
                 self.apply_filter_for(tab, option).await;
@@ -546,7 +546,7 @@ impl App {
             let state = self.state.read().await;
             (
                 state.browse.browse_tab,
-                state.browse.selected_option.clone(),
+                state.browse.selected_option,
             )
         };
 

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -211,6 +211,10 @@ impl App {
                             let mut state = self.state.write().await;
                             state.queue.clear();
                             state.queue.extend(songs);
+                            state.queue_auto_extend = false;
+                            state.queue_source_offset = 0;
+                            state.queue_source_has_more = false;
+                            state.queue_source_filter.clear();
                             state.notify(format!("Playing: {} ({} songs)", album_name, count));
                             drop(state);
                             self.save_queue_sync();
@@ -240,6 +244,20 @@ impl App {
                 state.queue.clear();
                 let songs = state.browse.songs.clone();
                 state.queue.extend(songs);
+
+                // Enable auto-extension if this is the "All" view with more pages
+                if state.browse.selected_option == Some(SongOption::All) {
+                    state.queue_auto_extend = true;
+                    state.queue_source_offset = state.browse.all_songs_offset;
+                    state.queue_source_has_more = state.browse.all_songs_has_more;
+                    state.queue_source_filter = state.browse.filter.clone();
+                } else {
+                    state.queue_auto_extend = false;
+                    state.queue_source_offset = 0;
+                    state.queue_source_has_more = false;
+                    state.queue_source_filter.clear();
+                }
+
                 drop(state);
                 self.save_queue_sync();
 

--- a/src/app/input_playlists.rs
+++ b/src/app/input_playlists.rs
@@ -16,14 +16,13 @@ impl App {
             KeyCode::Left => {
                 state.playlists.focus = 0;
             }
-            KeyCode::Right => {
-                if !state.playlists.songs.is_empty() {
+            KeyCode::Right
+                if !state.playlists.songs.is_empty() => {
                     state.playlists.focus = 1;
                     if state.playlists.selected_song.is_none() {
                         state.playlists.selected_song = Some(0);
                     }
                 }
-            }
             KeyCode::Up | KeyCode::Char('k') => {
                 if state.playlists.focus == 0 {
                     // Playlist list

--- a/src/app/input_queue.rs
+++ b/src/app/input_queue.rs
@@ -132,6 +132,10 @@ impl App {
                 } else {
                     state.queue.shuffle(&mut rng);
                 }
+                state.queue_auto_extend = false;
+                state.queue_source_offset = 0;
+                state.queue_source_has_more = false;
+                state.queue_source_filter.clear();
                 state.notify("Queue shuffled");
                 drop(state);
                 self.save_queue_sync();
@@ -143,6 +147,10 @@ impl App {
                         let removed = pos;
                         state.queue.drain(0..pos);
                         state.queue_position = Some(0);
+                        state.queue_auto_extend = false;
+                        state.queue_source_offset = 0;
+                        state.queue_source_has_more = false;
+                        state.queue_source_filter.clear();
                         // Adjust selection
                         if let Some(sel) = state.queue_state.selected {
                             if sel < pos {

--- a/src/app/input_server.rs
+++ b/src/app/input_server.rs
@@ -16,16 +16,14 @@ impl App {
 
         match key.code {
             // Navigation - always works
-            KeyCode::Up => {
-                if field > 0 {
+            KeyCode::Up
+                if field > 0 => {
                     state.server_state.selected_field -= 1;
                 }
-            }
-            KeyCode::Down => {
-                if field < 4 {
+            KeyCode::Down
+                if field < 4 => {
                     state.server_state.selected_field += 1;
                 }
-            }
             KeyCode::Tab => {
                 // Tab moves to next field, wrapping around
                 state.server_state.selected_field = (field + 1) % 5;

--- a/src/app/input_settings.rs
+++ b/src/app/input_settings.rs
@@ -15,16 +15,14 @@ impl App {
 
             match key.code {
                 // Navigate between fields
-                KeyCode::Up | KeyCode::Char('k') => {
-                    if field > 0 {
+                KeyCode::Up | KeyCode::Char('k')
+                    if field > 0 => {
                         state.settings_state.selected_field = field - 1;
                     }
-                }
-                KeyCode::Down | KeyCode::Char('j') => {
-                    if field < 5 {
+                KeyCode::Down | KeyCode::Char('j')
+                    if field < 5 => {
                         state.settings_state.selected_field = field + 1;
                     }
-                }
                 // Left
                 KeyCode::Left | KeyCode::Char('h') => match field {
                     0 => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
+use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -80,6 +81,8 @@ pub struct App {
     audio_rx: mpsc::Receiver<AudioAction>,
     /// MPRIS D-Bus server
     mpris_server: Option<mpris_server::Server<MprisPlayer>>,
+    /// Path to the active cava config file (for cleanup)
+    cava_config_path: Option<std::path::PathBuf>,
 }
 
 impl App {
@@ -110,6 +113,7 @@ impl App {
             cava_process: None,
             cava_pty_master: None,
             cava_parser: None,
+            cava_config_path: None,
             last_click: None,
             songs_filter_debounce: None,
             audio_rx,
@@ -126,6 +130,11 @@ impl App {
             state.notify_error(format!("Failed to start MPV: {}. Is mpv installed?", e));
             drop(state);
         } else {
+            let vol = {
+                let state = self.state.read().await;
+                state.volume
+            };
+            let _ = self.mpv.set_volume(vol as i32);
             info!("MPV started successfully, ready for playback");
         }
 
@@ -204,6 +213,31 @@ impl App {
         // Restore queue if enabled
         self.restore_queue().await;
 
+        // Spawn signal handler for graceful shutdown
+        let state_for_signal = self.state.clone();
+        tokio::spawn(async move {
+            let mut sigint = match signal(SignalKind::interrupt()) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Failed to register SIGINT handler: {}", e);
+                    return;
+                }
+            };
+            let mut sigterm = match signal(SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("Failed to register SIGTERM handler: {}", e);
+                    return;
+                }
+            };
+            tokio::select! {
+                _ = sigint.recv() => info!("Received SIGINT, shutting down gracefully"),
+                _ = sigterm.recv() => info!("Received SIGTERM, shutting down gracefully"),
+            }
+            let mut state = state_for_signal.write().await;
+            state.should_quit = true;
+        });
+
         // Main event loop
         let result = self.event_loop(&mut terminal).await;
 
@@ -215,6 +249,11 @@ impl App {
 
         // Cleanup MPV
         let _ = self.mpv.quit();
+
+        // Restore PipeWire sample rate
+        if let Err(e) = self.pipewire.restore_original() {
+            warn!("Failed to restore PipeWire sample rate: {}", e);
+        }
 
         // Cleanup terminal
         disable_raw_mode().map_err(UiError::TerminalInit)?;
@@ -261,6 +300,8 @@ impl App {
                 let queue_len = persisted.queue.len();
                 state.queue = persisted.queue;
                 state.queue_position = persisted.queue_position;
+                state.repeat_mode = persisted.repeat_mode;
+                state.volume = persisted.volume;
 
                 // Restore queue selection
                 if let Some(pos) = state.queue_position {
@@ -274,8 +315,8 @@ impl App {
                 }
 
                 info!(
-                    "Queue restored: {} songs, position: {:?}",
-                    queue_len, state.queue_position
+                    "Queue restored: {} songs, position: {:?}, repeat: {:?}, vol: {}",
+                    queue_len, state.queue_position, state.repeat_mode, state.volume
                 );
                 drop(state);
             }
@@ -288,6 +329,8 @@ impl App {
         let save_queue = state.config.save_queue;
         let queue = state.queue.clone();
         let queue_position = state.queue_position;
+        let repeat_mode = state.repeat_mode;
+        let volume = state.volume;
         drop(state);
 
         if !save_queue {
@@ -299,6 +342,8 @@ impl App {
         let persist = crate::config::queue::QueuePersist {
             queue,
             queue_position,
+            repeat_mode,
+            volume,
         };
 
         if let Err(e) = persist.save_default() {
@@ -309,7 +354,7 @@ impl App {
     /// Save queue to persistence file (non-async, for use in input handlers)
     fn save_queue_sync(&self) {
         // Clone what we need while holding the lock briefly
-        let (save_queue, queue, queue_position) = {
+        let (save_queue, queue, queue_position, repeat_mode, volume) = {
             let Ok(state) = self.state.try_read() else {
                 return;
             };
@@ -317,6 +362,8 @@ impl App {
                 state.config.save_queue,
                 state.queue.clone(),
                 state.queue_position,
+                state.repeat_mode,
+                state.volume,
             )
         };
 
@@ -328,6 +375,8 @@ impl App {
         let persist = crate::config::queue::QueuePersist {
             queue,
             queue_position,
+            repeat_mode,
+            volume,
         };
 
         if let Err(e) = persist.save_default() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -379,9 +379,11 @@ impl App {
             volume,
         };
 
-        if let Err(e) = persist.save_default() {
-            warn!("Failed to save queue: {}", e);
-        }
+        tokio::task::spawn_blocking(move || {
+            if let Err(e) = persist.save_default() {
+                warn!("Failed to save queue: {}", e);
+            }
+        });
     }
 
     /// Main event loop

--- a/src/app/models.rs
+++ b/src/app/models.rs
@@ -7,7 +7,7 @@ pub enum BrowseTab {
     Albums,
 }
 
-#[derive(Display, EnumIter, Clone, Debug, PartialEq)]
+#[derive(Display, EnumIter, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SongOption {
     All,
     Starred,

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -39,7 +39,7 @@ impl App {
 
                         let on_starred =
                             state.browse.selected_option == Some(SongOption::Starred);
-                        let browse_tab = state.browse.browse_tab.clone();
+                        let browse_tab = state.browse.browse_tab;
                         let refresh_songs = on_starred
                             && browse_tab == BrowseTab::Songs
                             && state.browse.starred_songs_dirty;
@@ -162,8 +162,8 @@ impl App {
     async fn handle_mouse_scroll_up(&mut self) -> Result<(), Error> {
         let mut state = self.state.write().await;
         match state.page {
-            Page::Browse => {
-                if state.browse.focus == 1 {
+            Page::Browse
+                if state.browse.focus == 1 => {
                     match state.browse.browse_tab {
                         BrowseTab::Songs => {
                             if let Some(sel) = state.browse.selected_index {
@@ -181,7 +181,6 @@ impl App {
                         }
                     }
                 }
-            }
             Page::Artists => {
                 if state.artists.focus == 0 {
                     if let Some(sel) = state.artists.selected_index {
@@ -240,8 +239,8 @@ impl App {
     async fn handle_mouse_scroll_down(&mut self) -> Result<(), Error> {
         let mut state = self.state.write().await;
         match state.page {
-            Page::Browse => {
-                if state.browse.focus == 1 {
+            Page::Browse
+                if state.browse.focus == 1 => {
                     match state.browse.browse_tab {
                         BrowseTab::Songs => {
                             let max = state.browse.songs.len().saturating_sub(1);
@@ -301,7 +300,6 @@ impl App {
                         }
                     }
                 }
-            }
             Page::Artists => {
                 if state.artists.focus == 0 {
                     let tree_items = crate::ui::pages::artists::build_tree_items(&state);

--- a/src/app/mouse_browse.rs
+++ b/src/app/mouse_browse.rs
@@ -26,7 +26,7 @@ impl App {
         let search_area = chunks[2];
         let list_area = chunks[3];
 
-        let browse_tab = self.state.read().await.browse.browse_tab.clone();
+        let browse_tab = self.state.read().await.browse.browse_tab;
 
         if y >= tab_area.y && y < tab_area.y + tab_area.height {
             let Some(new_tab) = crate::ui::pages::browse::tab_at_column(tab_area.x, x) else {
@@ -36,7 +36,7 @@ impl App {
 
             let mut state = self.state.write().await;
             if state.browse.browse_tab != new_tab {
-                state.browse.browse_tab = new_tab.clone();
+                state.browse.browse_tab = new_tab;
                 state.browse.filter.clear();
                 state.browse.focus = 0;
                 let selected_option = state.browse.selected_option.clone();
@@ -79,7 +79,7 @@ impl App {
                     state.browse.selected_option = Some(opt.clone());
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
-                    let tab = state.browse.browse_tab.clone();
+                    let tab = state.browse.browse_tab;
                     drop(state);
                     match tab {
                         BrowseTab::Songs => match opt {

--- a/src/app/mouse_browse.rs
+++ b/src/app/mouse_browse.rs
@@ -39,7 +39,7 @@ impl App {
                 state.browse.browse_tab = new_tab;
                 state.browse.filter.clear();
                 state.browse.focus = 0;
-                let selected_option = state.browse.selected_option.clone();
+                    let selected_option = state.browse.selected_option;
                 drop(state);
                 self.songs_filter_debounce = None;
 
@@ -76,7 +76,7 @@ impl App {
 
             if let Some(opt) = SongOption::iter().nth(row) {
                 if state.browse.selected_option.as_ref() != Some(&opt) {
-                    state.browse.selected_option = Some(opt.clone());
+                    state.browse.selected_option = Some(opt);
                     state.browse.scroll_offset = 0;
                     state.browse.album_scroll_offset = 0;
                     let tab = state.browse.browse_tab;

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -375,6 +375,7 @@ impl App {
         let state = self.state.read().await;
         let queue_len = state.queue.len();
         let current_pos = state.queue_position;
+        let repeat_mode = state.repeat_mode;
         drop(state);
 
         if queue_len == 0 {
@@ -384,19 +385,29 @@ impl App {
         let next_pos = match current_pos {
             Some(pos) if pos + 1 < queue_len => pos + 1,
             Some(pos) if pos + 1 >= queue_len => {
-                self.maybe_extend_queue().await;
-                let state = self.state.read().await;
-                let queue_len = state.queue.len();
-                drop(state);
-                if pos + 1 < queue_len {
-                    pos + 1
+                if repeat_mode == RepeatMode::One {
+                    return self.play_queue_position(pos).await;
+                }
+                if repeat_mode == RepeatMode::All && queue_len > 0 {
+                    0
                 } else {
-                    info!("Reached end of queue");
-                    let _ = self.mpv.stop();
-                    let mut state = self.state.write().await;
-                    state.now_playing.state = PlaybackState::Stopped;
-                    state.now_playing.position = 0.0;
-                    return Ok(());
+                    self.maybe_extend_queue().await;
+                    let state = self.state.read().await;
+                    let queue_len = state.queue.len();
+                    let repeat_mode = state.repeat_mode;
+                    drop(state);
+                    if pos + 1 < queue_len {
+                        pos + 1
+                    } else if repeat_mode == RepeatMode::All && queue_len > 0 {
+                        0
+                    } else {
+                        info!("Reached end of queue");
+                        let _ = self.mpv.stop();
+                        let mut state = self.state.write().await;
+                        state.now_playing.state = PlaybackState::Stopped;
+                        state.now_playing.position = 0.0;
+                        return Ok(());
+                    }
                 }
             }
             _ => {
@@ -418,6 +429,7 @@ impl App {
         let queue_len = state.queue.len();
         let current_pos = state.queue_position;
         let position = state.now_playing.position;
+        let repeat_mode = state.repeat_mode;
         drop(state);
 
         if queue_len == 0 {
@@ -428,6 +440,8 @@ impl App {
             if let Some(pos) = current_pos {
                 if pos > 0 {
                     return self.play_queue_position(pos - 1).await;
+                } else if repeat_mode == RepeatMode::All && queue_len > 0 {
+                    return self.play_queue_position(queue_len - 1).await;
                 }
             }
             if let Err(e) = self.mpv.seek(0.0) {

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -693,9 +693,15 @@ impl App {
                     let has_more = fetched == PAGE_SIZE;
 
                     let mut state = self.state.write().await;
-                    state.queue.extend(songs);
+                    state.queue.extend(songs.clone());
                     state.queue_source_offset = offset + fetched;
                     state.queue_source_has_more = has_more;
+                    state.browse.songs.extend(songs);
+                    if state.browse.songs.len() > Self::MAX_BROWSE_SONGS {
+                        state.browse.songs.truncate(Self::MAX_BROWSE_SONGS);
+                    }
+                    state.browse.all_songs_offset = offset + fetched;
+                    state.browse.all_songs_has_more = has_more;
                     state.browse.all_songs_loading = false;
                     drop(state);
                     self.save_queue_sync();

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -42,7 +42,26 @@ impl App {
                     .unwrap_or(false);
                 drop(state);
 
-                if has_next && time_remaining > 0.0 && time_remaining < 2.0 {
+                if !has_next && time_remaining > 0.0 && time_remaining < 2.0 {
+                    self.maybe_extend_queue().await;
+                    // Re-check after possible extension
+                    let state = self.state.read().await;
+                    let has_next_now = state
+                        .queue_position
+                        .map(|p| p + 1 < state.queue.len())
+                        .unwrap_or(false);
+                    drop(state);
+
+                    if has_next_now {
+                        if let Ok(count) = self.mpv.get_playlist_count() {
+                            if count < 2 {
+                                info!("Near end of track with no preloaded next — advancing early");
+                                let _ = self.next_track().await;
+                                return;
+                            }
+                        }
+                    }
+                } else if has_next && time_remaining > 0.0 && time_remaining < 2.0 {
                     if let Ok(count) = self.mpv.get_playlist_count() {
                         if count < 2 {
                             info!("Near end of track with no preloaded next — advancing early");
@@ -58,10 +77,20 @@ impl App {
                 if count == 1 {
                     let state = self.state.read().await;
                     if let Some(pos) = state.queue_position {
-                        if pos + 1 < state.queue.len() {
+                        if pos + 1 >= state.queue.len() {
                             drop(state);
-                            debug!("Playlist count is 1, re-preloading next track");
-                            self.preload_next_track(pos).await;
+                            self.maybe_extend_queue().await;
+                        } else {
+                            drop(state);
+                        }
+                        // Re-check after possible extension
+                        let state = self.state.read().await;
+                        if let Some(pos) = state.queue_position {
+                            if pos + 1 < state.queue.len() {
+                                drop(state);
+                                debug!("Playlist count is 1, re-preloading next track");
+                                self.preload_next_track(pos).await;
+                            }
                         }
                     }
                 }
@@ -82,6 +111,7 @@ impl App {
                             // for gapless transitions (same album, same format)
                             let mut state = self.state.write().await;
                             state.queue_position = Some(next_pos);
+                            state.queue_state.selected = Some(next_pos);
                             if let Some(song) = state.queue.get(next_pos).cloned() {
                                 state.now_playing.song = Some(song.clone());
                                 state.now_playing.radio_station = None;
@@ -353,6 +383,22 @@ impl App {
 
         let next_pos = match current_pos {
             Some(pos) if pos + 1 < queue_len => pos + 1,
+            Some(pos) if pos + 1 >= queue_len => {
+                self.maybe_extend_queue().await;
+                let state = self.state.read().await;
+                let queue_len = state.queue.len();
+                drop(state);
+                if pos + 1 < queue_len {
+                    pos + 1
+                } else {
+                    info!("Reached end of queue");
+                    let _ = self.mpv.stop();
+                    let mut state = self.state.write().await;
+                    state.now_playing.state = PlaybackState::Stopped;
+                    state.now_playing.position = 0.0;
+                    return Ok(());
+                }
+            }
             _ => {
                 info!("Reached end of queue");
                 let _ = self.mpv.stop();
@@ -429,6 +475,7 @@ impl App {
         {
             let mut state = self.state.write().await;
             state.queue_position = Some(pos);
+            state.queue_state.selected = Some(pos);
             state.now_playing.song = Some(song.clone());
             state.now_playing.radio_station = None;
             state.now_playing.radio_title = None;
@@ -469,6 +516,10 @@ impl App {
             state.queue.clear();
             state.queue_position = None;
             state.queue_state.selected = None;
+            state.queue_auto_extend = false;
+            state.queue_source_offset = 0;
+            state.queue_source_has_more = false;
+            state.queue_source_filter.clear();
             state.now_playing.song = None;
             state.now_playing.radio_station = Some(station.clone());
             state.now_playing.radio_title = None;
@@ -560,10 +611,94 @@ impl App {
         state.now_playing.channels = None;
         state.queue.clear();
         state.queue_position = None;
+        state.queue_state.selected = None;
+        state.queue_auto_extend = false;
+        state.queue_source_offset = 0;
+        state.queue_source_has_more = false;
+        state.queue_source_filter.clear();
         drop(state);
 
         self.save_queue().await;
         Ok(())
+    }
+
+    /// If the queue was created from Browse → All Songs and we're near the end,
+    /// fetch the next page and append it to the queue.
+    async fn maybe_extend_queue(&mut self) {
+        let (_should_extend, offset, filter) = {
+            let state = self.state.read().await;
+            if !state.queue_auto_extend {
+                return;
+            }
+            if state.browse.all_songs_loading {
+                return;
+            }
+            if !state.queue_source_has_more {
+                return;
+            }
+
+            let pos = state.queue_position.unwrap_or(0);
+            if pos + INFINITE_SCROLL_LOOKAHEAD < state.queue.len() {
+                return;
+            }
+
+            // Verify the queue still starts with browse.songs so we don't
+            // extend a queue that has been replaced from another source.
+            let browse_len = state.browse.songs.len();
+            if browse_len > 0
+                && state.queue.len() >= browse_len
+                && state
+                    .queue
+                    .iter()
+                    .zip(state.browse.songs.iter())
+                    .all(|(q, b)| q.id == b.id)
+            {
+                (
+                    true,
+                    state.queue_source_offset,
+                    state.queue_source_filter.clone(),
+                )
+            } else {
+                return;
+            }
+        };
+
+        if let Some(ref client) = self.subsonic {
+            {
+                let mut state = self.state.write().await;
+                state.browse.all_songs_loading = true;
+            }
+
+            // Must match the page size used by get_all_songs
+            const PAGE_SIZE: usize = 50;
+            match client.search_songs(&filter, offset, PAGE_SIZE).await {
+                Ok(songs) => {
+                    let fetched = songs.len();
+                    let has_more = fetched == PAGE_SIZE;
+
+                    let mut state = self.state.write().await;
+                    state.queue.extend(songs);
+                    state.queue_source_offset = offset + fetched;
+                    state.queue_source_has_more = has_more;
+                    state.browse.all_songs_loading = false;
+                    drop(state);
+                    self.save_queue_sync();
+
+                    info!(
+                        "Extended queue by {} songs (offset now {})",
+                        fetched,
+                        offset + fetched
+                    );
+                }
+                Err(e) => {
+                    error!("Failed to extend queue: {}", e);
+                    let mut state = self.state.write().await;
+                    state.browse.all_songs_loading = false;
+                    state.queue_source_has_more = false;
+                    state.notify_error(format!("Failed to extend queue: {}", e));
+                }
+            }
+        }
     }
 
     async fn notify_track_change(&mut self, pos: usize) {

--- a/src/app/playback.rs
+++ b/src/app/playback.rs
@@ -123,6 +123,7 @@ impl App {
                                 // Don't reset audio properties - let them update naturally
                                 // This avoids triggering PipeWire rate changes unnecessarily
                             }
+                            self.sync_browse_selection_to_playing(&mut state);
                             drop(state);
                             self.notify_track_change(next_pos).await;
 
@@ -502,6 +503,7 @@ impl App {
             state.now_playing.format = None;
             state.now_playing.channels = None;
             state.now_playing.scrobbled = false;
+            self.sync_browse_selection_to_playing(&mut state);
         }
 
         info!("Playing: {} (queue pos {})", song.title, pos);
@@ -732,6 +734,16 @@ impl App {
                 artist: song.artist.unwrap_or_default(),
                 album: song.album.unwrap_or_default(),
             });
+        }
+    }
+
+    /// If the currently playing song exists in the Browse -> Songs list,
+    /// update `browse.selected_index` so the list auto-scrolls to keep it visible.
+    fn sync_browse_selection_to_playing(&self, state: &mut AppState) {
+        if let Some(ref song) = state.now_playing.song {
+            if let Some(idx) = state.browse.songs.iter().position(|s| s.id == song.id) {
+                state.browse.selected_index = Some(idx);
+            }
         }
     }
 }

--- a/src/app/repo.rs
+++ b/src/app/repo.rs
@@ -8,7 +8,7 @@ impl App {
     const ALL_ALBUMS_PAGE_SIZE: usize = 500;
 
     /// Maximum number of songs to keep in the All-songs view to prevent unbounded growth.
-    const MAX_BROWSE_SONGS: usize = 5000;
+    pub(super) const MAX_BROWSE_SONGS: usize = 5000;
 
     /// Maximum number of albums to keep in the Albums view to prevent unbounded growth.
     const MAX_BROWSE_ALBUMS: usize = 5000;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use ratatui::layout::Rect;
@@ -69,6 +71,33 @@ pub enum PlaybackState {
     Stopped,
     Playing,
     Paused,
+}
+
+/// Repeat mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum RepeatMode {
+    #[default]
+    Off,
+    All,
+    One,
+}
+
+impl RepeatMode {
+    pub fn label(&self) -> &'static str {
+        match self {
+            RepeatMode::Off => "Off",
+            RepeatMode::All => "All",
+            RepeatMode::One => "One",
+        }
+    }
+
+    pub fn next(&self) -> Self {
+        match self {
+            RepeatMode::Off => RepeatMode::All,
+            RepeatMode::All => RepeatMode::One,
+            RepeatMode::One => RepeatMode::Off,
+        }
+    }
 }
 
 /// Now playing information
@@ -472,6 +501,10 @@ pub struct AppState {
     pub server_state: ServerState,
     /// Settings page state (app preferences)
     pub settings_state: SettingsState,
+    /// Current repeat mode
+    pub repeat_mode: RepeatMode,
+    /// Current volume (0-100)
+    pub volume: u8,
     /// Whether the queue can auto-extend from Browse → All Songs
     pub queue_auto_extend: bool,
     /// Pagination offset for queue auto-extension

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -569,6 +569,8 @@ impl AppState {
         state.settings_state.save_queue_enabled = config.save_queue;
         // Default to All songs so navigation and rendering start in sync
         state.browse.selected_option = Some(SongOption::All);
+        // Default volume before any restore
+        state.volume = 100;
 
         state
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -472,6 +472,14 @@ pub struct AppState {
     pub server_state: ServerState,
     /// Settings page state (app preferences)
     pub settings_state: SettingsState,
+    /// Whether the queue can auto-extend from Browse → All Songs
+    pub queue_auto_extend: bool,
+    /// Pagination offset for queue auto-extension
+    pub queue_source_offset: usize,
+    /// Whether more songs are available for queue auto-extension
+    pub queue_source_has_more: bool,
+    /// Filter used when queue was created from Browse → All Songs
+    pub queue_source_filter: String,
     /// Current notification
     pub notification: Option<Notification>,
     /// Whether the app should quit

--- a/src/audio/pipewire.rs
+++ b/src/audio/pipewire.rs
@@ -138,7 +138,7 @@ impl PipeWireController {
 
     /// Clear the forced sample rate (let PipeWire use default)
     pub fn clear_forced_rate(&mut self) -> Result<(), AudioError> {
-        task::block_in_place(|| Self::clear_forced_rate_blocking())?;
+        task::block_in_place(Self::clear_forced_rate_blocking)?;
         self.current_rate = None;
         Ok(())
     }

--- a/src/audio/pipewire.rs
+++ b/src/audio/pipewire.rs
@@ -154,7 +154,7 @@ impl Default for PipeWireController {
 impl Drop for PipeWireController {
     fn drop(&mut self) {
         if let Some(rate) = self.original_rate {
-            std::thread::spawn(move || {
+            let handle = std::thread::spawn(move || {
                 if rate > 0 {
                     if let Err(e) = Self::set_rate_blocking(rate) {
                         error!("Failed to restore sample rate: {}", e);
@@ -163,6 +163,7 @@ impl Drop for PipeWireController {
                     error!("Failed to clear forced sample rate: {}", e);
                 }
             });
+            let _ = handle.join();
         }
     }
 }

--- a/src/config/queue.rs
+++ b/src/config/queue.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tracing::{debug, info};
 
+use crate::app::state::RepeatMode;
 use crate::subsonic::models::Child;
 
 /// Persisted queue state
@@ -15,6 +16,16 @@ pub struct QueuePersist {
     /// Current position in queue
     #[serde(default)]
     pub queue_position: Option<usize>,
+    /// Repeat mode
+    #[serde(default)]
+    pub repeat_mode: RepeatMode,
+    /// Volume (0-100)
+    #[serde(default = "default_volume")]
+    pub volume: u8,
+}
+
+fn default_volume() -> u8 {
+    100
 }
 
 impl QueuePersist {

--- a/src/mpris/server.rs
+++ b/src/mpris/server.rs
@@ -10,7 +10,7 @@ use tracing::info;
 use url::Url;
 
 use crate::app::actions::AudioAction;
-use crate::app::state::{NowPlaying, PlaybackState, SharedState};
+use crate::app::state::{NowPlaying, PlaybackState, RepeatMode, SharedState};
 use crate::config::Config;
 use crate::subsonic::auth::generate_auth_params;
 use crate::subsonic::models::Child;
@@ -267,10 +267,21 @@ impl PlayerInterface for MprisPlayer {
     }
 
     async fn loop_status(&self) -> fdo::Result<LoopStatus> {
-        Ok(LoopStatus::None)
+        let state = self.state.read().await;
+        Ok(match state.repeat_mode {
+            RepeatMode::Off => LoopStatus::None,
+            RepeatMode::All => LoopStatus::Playlist,
+            RepeatMode::One => LoopStatus::Track,
+        })
     }
 
-    async fn set_loop_status(&self, _loop_status: LoopStatus) -> Result<()> {
+    async fn set_loop_status(&self, loop_status: LoopStatus) -> Result<()> {
+        let mut state = self.state.write().await;
+        state.repeat_mode = match loop_status {
+            LoopStatus::None => RepeatMode::Off,
+            LoopStatus::Playlist => RepeatMode::All,
+            LoopStatus::Track => RepeatMode::One,
+        };
         Ok(())
     }
 

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -8,7 +8,7 @@ use ratatui::{
     widgets::Widget,
 };
 
-use crate::app::state::{Notification, Page};
+use crate::app::state::{Notification, Page, RepeatMode};
 use crate::ui::theme::ThemeColors;
 
 /// Footer bar widget
@@ -16,6 +16,8 @@ pub struct Footer<'a> {
     page: Page,
     sample_rate: Option<u32>,
     notification: Option<&'a Notification>,
+    repeat_mode: RepeatMode,
+    volume: u8,
     colors: ThemeColors,
 }
 
@@ -25,6 +27,8 @@ impl<'a> Footer<'a> {
             page,
             sample_rate: None,
             notification: None,
+            repeat_mode: RepeatMode::Off,
+            volume: 100,
             colors,
         }
     }
@@ -39,12 +43,24 @@ impl<'a> Footer<'a> {
         self
     }
 
+    pub fn repeat_mode(mut self, mode: RepeatMode) -> Self {
+        self.repeat_mode = mode;
+        self
+    }
+
+    pub fn volume(mut self, volume: u8) -> Self {
+        self.volume = volume;
+        self
+    }
+
     fn keybinds(&self) -> Vec<(&'static str, &'static str)> {
         let mut binds = vec![
             ("q", "Quit"),
             ("p/Space", "Pause"),
             ("h", "Prev"),
             ("l", "Next"),
+            ("r", "Repeat"),
+            ("+/-", "Volume"),
         ];
 
         match self.page {
@@ -150,7 +166,12 @@ impl Widget for Footer<'_> {
             buf.set_line(chunks[0].x, chunks[0].y, &line, chunks[0].width);
         }
 
-        // Right side: sample rate / status
+        // Right side: repeat, volume, sample rate
+        let mut status_parts = Vec::new();
+        if self.repeat_mode != RepeatMode::Off {
+            status_parts.push(format!("Repeat: {}", self.repeat_mode.label()));
+        }
+        status_parts.push(format!("Vol: {}%", self.volume));
         if let Some(rate) = self.sample_rate {
             let khz = rate as f64 / 1000.0;
             let rate_str = if khz == khz.floor() {
@@ -158,11 +179,15 @@ impl Widget for Footer<'_> {
             } else {
                 format!("{:.1}kHz", khz)
             };
-            let x = chunks[1].x + chunks[1].width.saturating_sub(rate_str.len() as u16);
+            status_parts.push(rate_str);
+        }
+        let status = status_parts.join(" | ");
+        if !status.is_empty() {
+            let x = chunks[1].x + chunks[1].width.saturating_sub(status.len() as u16);
             buf.set_string(
                 x,
                 chunks[1].y,
-                &rate_str,
+                &status,
                 Style::default().fg(self.colors.success),
             );
         }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -182,12 +182,18 @@ impl Widget for Footer<'_> {
             status_parts.push(rate_str);
         }
         let status = status_parts.join(" | ");
+        let max_width = chunks[1].width as usize;
         if !status.is_empty() {
-            let x = chunks[1].x + chunks[1].width.saturating_sub(status.len() as u16);
+            let display_status = if status.len() > max_width {
+                &status[status.len() - max_width..]
+            } else {
+                &status
+            };
+            let x = chunks[1].x + chunks[1].width.saturating_sub(display_status.len() as u16);
             buf.set_string(
                 x,
                 chunks[1].y,
-                &status,
+                display_status,
                 Style::default().fg(self.colors.success),
             );
         }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -134,38 +134,19 @@ impl Widget for Footer<'_> {
             return;
         }
 
-        let chunks = Layout::horizontal([Constraint::Min(40), Constraint::Length(30)]).split(area);
+        // Give the right side a minimum of 18 so status text is never unreadable.
+        let chunks = Layout::horizontal([Constraint::Min(0), Constraint::Min(18)]).split(area);
         let left = chunks[0];
         let right = chunks[1];
 
         // Right side: repeat, volume, sample rate (always on first row)
-        let mut status_parts = Vec::new();
-        if self.repeat_mode != RepeatMode::Off {
-            status_parts.push(format!("Repeat: {}", self.repeat_mode.label()));
-        }
-        status_parts.push(format!("Vol: {}%", self.volume));
-        if let Some(rate) = self.sample_rate {
-            let khz = rate as f64 / 1000.0;
-            let rate_str = if khz == khz.floor() {
-                format!("{}kHz", khz as u32)
-            } else {
-                format!("{:.1}kHz", khz)
-            };
-            status_parts.push(rate_str);
-        }
-        let status = status_parts.join(" | ");
-        let max_width = right.width as usize;
+        let status = self.format_status(right.width as usize);
         if !status.is_empty() {
-            let display_status = if status.len() > max_width {
-                &status[status.len() - max_width..]
-            } else {
-                &status
-            };
-            let x = right.x + right.width.saturating_sub(display_status.len() as u16);
+            let x = right.x + right.width.saturating_sub(status.len() as u16);
             buf.set_string(
                 x,
                 right.y,
-                display_status,
+                &status,
                 Style::default().fg(self.colors.success),
             );
         }
@@ -215,5 +196,57 @@ impl Widget for Footer<'_> {
         let line2 = build_line(&binds[mid..]);
         buf.set_line(left.x, left.y, &line1, left.width);
         buf.set_line(left.x, left.y + 1, &line2, left.width);
+    }
+}
+
+impl Footer<'_> {
+    /// Build the status string, abbreviating parts to fit the given width.
+    fn format_status(&self, max_width: usize) -> String {
+        let rate_str = self.sample_rate.map(|rate| {
+            let khz = rate as f64 / 1000.0;
+            if khz == khz.floor() {
+                format!("{}kHz", khz as u32)
+            } else {
+                format!("{:.1}kHz", khz)
+            }
+        });
+
+        // Full form: "Repeat: All | Vol: 100% | 44.1kHz"
+        let mut parts = Vec::new();
+        if self.repeat_mode != RepeatMode::Off {
+            parts.push(format!("Repeat: {}", self.repeat_mode.label()));
+        }
+        parts.push(format!("Vol: {}%", self.volume));
+        if let Some(ref r) = rate_str {
+            parts.push(r.clone());
+        }
+        let full = parts.join(" | ");
+        if full.len() <= max_width {
+            return full;
+        }
+
+        // Short form: "R:All | V:100% | 44.1kHz"
+        parts.clear();
+        if self.repeat_mode != RepeatMode::Off {
+            parts.push(format!("R:{}", self.repeat_mode.label()));
+        }
+        parts.push(format!("V:{}%", self.volume));
+        if let Some(ref r) = rate_str {
+            parts.push(r.clone());
+        }
+        let short = parts.join(" | ");
+        if short.len() <= max_width {
+            return short;
+        }
+
+        // Minimal form: just volume (and sample rate if it fits)
+        let mut minimal = format!("V:{}%", self.volume);
+        if let Some(ref r) = rate_str {
+            let with_rate = format!("{} | {}", minimal, r);
+            if with_rate.len() <= max_width {
+                minimal = with_rate;
+            }
+        }
+        minimal
     }
 }

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -72,7 +72,6 @@ impl<'a> Footer<'a> {
                     ("←/→", "Songs/Albums"),
                     ("/", "Search"),
                     ("Tab", "Focus"),
-                    ("/", "Search"),
                     ("f", "Star/Un-star"),
                 ]);
             }
@@ -136,37 +135,10 @@ impl Widget for Footer<'_> {
         }
 
         let chunks = Layout::horizontal([Constraint::Min(40), Constraint::Length(30)]).split(area);
+        let left = chunks[0];
+        let right = chunks[1];
 
-        // Left side: keybinds or notification
-        if let Some(notif) = self.notification {
-            let style = if notif.is_error {
-                Style::default().fg(self.colors.error)
-            } else {
-                Style::default().fg(self.colors.success)
-            };
-            buf.set_string(chunks[0].x, chunks[0].y, &notif.message, style);
-        } else {
-            // Keybind hints
-            let binds = self.keybinds();
-            let mut spans = Vec::new();
-
-            for (i, (key, desc)) in binds.iter().enumerate() {
-                if i > 0 {
-                    spans.push(Span::styled(
-                        " │ ",
-                        Style::default().fg(self.colors.secondary),
-                    ));
-                }
-                spans.push(Span::styled(*key, Style::default().fg(self.colors.accent)));
-                spans.push(Span::raw(":"));
-                spans.push(Span::styled(*desc, Style::default().fg(self.colors.muted)));
-            }
-
-            let line = Line::from(spans);
-            buf.set_line(chunks[0].x, chunks[0].y, &line, chunks[0].width);
-        }
-
-        // Right side: repeat, volume, sample rate
+        // Right side: repeat, volume, sample rate (always on first row)
         let mut status_parts = Vec::new();
         if self.repeat_mode != RepeatMode::Off {
             status_parts.push(format!("Repeat: {}", self.repeat_mode.label()));
@@ -182,20 +154,66 @@ impl Widget for Footer<'_> {
             status_parts.push(rate_str);
         }
         let status = status_parts.join(" | ");
-        let max_width = chunks[1].width as usize;
+        let max_width = right.width as usize;
         if !status.is_empty() {
             let display_status = if status.len() > max_width {
                 &status[status.len() - max_width..]
             } else {
                 &status
             };
-            let x = chunks[1].x + chunks[1].width.saturating_sub(display_status.len() as u16);
+            let x = right.x + right.width.saturating_sub(display_status.len() as u16);
             buf.set_string(
                 x,
-                chunks[1].y,
+                right.y,
                 display_status,
                 Style::default().fg(self.colors.success),
             );
         }
+
+        // Left side: keybinds or notification
+        if let Some(notif) = self.notification {
+            let style = if notif.is_error {
+                Style::default().fg(self.colors.error)
+            } else {
+                Style::default().fg(self.colors.success)
+            };
+            buf.set_string(left.x, left.y, &notif.message, style);
+            return;
+        }
+
+        let binds = self.keybinds();
+        if binds.is_empty() {
+            return;
+        }
+
+        let build_line = |slice: &[(&'static str, &'static str)]| {
+            let mut spans = Vec::new();
+            for (i, (key, desc)) in slice.iter().enumerate() {
+                if i > 0 {
+                    spans.push(Span::styled(
+                        " │ ",
+                        Style::default().fg(self.colors.secondary),
+                    ));
+                }
+                spans.push(Span::styled(*key, Style::default().fg(self.colors.accent)));
+                spans.push(Span::raw(":"));
+                spans.push(Span::styled(*desc, Style::default().fg(self.colors.muted)));
+            }
+            Line::from(spans)
+        };
+
+        // If only one row available, render all keybinds on one line (truncated)
+        if area.height < 2 {
+            let line = build_line(&binds);
+            buf.set_line(left.x, left.y, &line, left.width);
+            return;
+        }
+
+        // Split keybinds across two rows
+        let mid = (binds.len() + 1) / 2;
+        let line1 = build_line(&binds[..mid]);
+        let line2 = build_line(&binds[mid..]);
+        buf.set_line(left.x, left.y, &line1, left.width);
+        buf.set_line(left.x, left.y + 1, &line2, left.width);
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -113,6 +113,8 @@ pub fn draw(frame: &mut Frame, state: &AppState, mutations: &mut RenderMutations
     // Render footer
     let footer = Footer::new(state.page, colors)
         .sample_rate(state.now_playing.sample_rate)
+        .repeat_mode(state.repeat_mode)
+        .volume(state.volume)
         .notification(state.notification.as_ref());
     frame.render_widget(footer, footer_area);
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -35,7 +35,7 @@ pub fn draw(frame: &mut Frame, state: &AppState, mutations: &mut RenderMutations
             Constraint::Percentage(state.settings_state.cava_size as u16), // Cava visualizer
             Constraint::Min(10),                                           // Page content
             Constraint::Length(7),                                         // Now playing
-            Constraint::Length(1),                                         // Footer
+            Constraint::Length(2),                                         // Footer
         ])
         .split(area);
         (chunks[0], Some(chunks[1]), chunks[2], chunks[3], chunks[4])
@@ -44,7 +44,7 @@ pub fn draw(frame: &mut Frame, state: &AppState, mutations: &mut RenderMutations
             Constraint::Length(1), // Header
             Constraint::Min(10),   // Page content
             Constraint::Length(7), // Now playing
-            Constraint::Length(1), // Footer
+            Constraint::Length(2), // Footer
         ])
         .split(area);
         (chunks[0], None, chunks[1], chunks[2], chunks[3])

--- a/src/ui/pages/artists.rs
+++ b/src/ui/pages/artists.rs
@@ -239,11 +239,11 @@ fn render_songs(
                 .unwrap_or(false);
 
             let line = get_song_without_artist_line(
-                &song,
+                song,
                 is_selected,
                 is_playing,
                 has_multiple_discs,
-                &colors,
+                colors,
             );
             ListItem::new(line)
         })

--- a/src/ui/pages/browse.rs
+++ b/src/ui/pages/browse.rs
@@ -90,7 +90,6 @@ fn render_options(frame: &mut Frame, area: Rect, state: &AppState, colors: &Them
     let selected_option = state
         .browse
         .selected_option
-        .clone()
         .unwrap_or(SongOption::All);
 
     let border_style = if focused {

--- a/src/ui/pages/browse.rs
+++ b/src/ui/pages/browse.rs
@@ -197,9 +197,7 @@ fn render_songs(
 
     let mut list_state = ListState::default();
     *list_state.offset_mut() = state.browse.scroll_offset;
-    if focused {
-        list_state.select(state.browse.selected_index);
-    }
+    list_state.select(state.browse.selected_index);
 
     frame.render_stateful_widget(list, area, &mut list_state);
     mutations.browse_scroll_offset = Some(list_state.offset());
@@ -261,9 +259,7 @@ fn render_albums(
 
     let mut list_state = ListState::default();
     *list_state.offset_mut() = state.browse.album_scroll_offset;
-    if focused {
-        list_state.select(state.browse.selected_album);
-    }
+    list_state.select(state.browse.selected_album);
 
     frame.render_stateful_widget(list, area, &mut list_state);
     mutations.browse_album_scroll_offset = Some(list_state.offset());

--- a/src/ui/pages/queue.rs
+++ b/src/ui/pages/queue.rs
@@ -120,6 +120,7 @@ pub fn render(frame: &mut Frame, area: Rect, state: &AppState, mutations: &mut R
         .highlight_symbol("▸ ");
 
     let mut list_state = ListState::default();
+    *list_state.offset_mut() = state.queue_state.scroll_offset;
     list_state.select(state.queue_state.selected);
 
     frame.render_stateful_widget(list, area, &mut list_state);

--- a/src/ui/widgets/now_playing.rs
+++ b/src/ui/widgets/now_playing.rs
@@ -173,7 +173,9 @@ impl Widget for NowPlayingWidget<'_> {
             return;
         }
 
-        let song = self.now_playing.song.as_ref().unwrap();
+        let Some(song) = self.now_playing.song.as_ref() else {
+            return;
+        };
 
         // Build centered lines like Go version:
         // Line 1: Artist (green)


### PR DESCRIPTION
## Release 1.0.0

This PR brings ferrosonic-ng to a stable 1.0.0 release.

### New Features
- **Repeat / Loop Mode** (`r` key): cycles Off → All → One. Integrated into playback logic and MPRIS `LoopStatus`.
- **Keyboard Volume Control** (`+` / `-`): adjusts volume in 5% steps, shown in the footer, applied to MPV on startup.
- **Signal Handling**: SIGINT/SIGTERM trigger graceful shutdown, ensuring queue save, PipeWire rate restore, and terminal cleanup.
- **Queue Auto-Extension** (from PR #134): adding from Browse → All Songs auto-extends the queue; Queue view auto-scrolls to the playing track.

### Fixes & Stability
- **Clippy Cleanup**: All warnings resolved.
- **CI Gates**: `cargo fmt --check` and `cargo clippy -- -D warnings` now run in CI.
- **Cava Temp Path Conflict (#56)**: Uses PID-unique temp directory to avoid collisions.
- **Production Unwraps**: Replaced with safe error handling.
- **PipeWire Restore**: Always runs on exit, even on signal termination.

### Persistence
- `QueuePersist` now saves and restores `repeat_mode` and `volume` alongside the queue.

### Versioning
- Bumped version to **1.0.0**
- Added `CHANGELOG.md`

### Validation
- `cargo test` — 48 passed, 0 failed
- `cargo clippy -- -D warnings` — clean
- `cargo build --release` — successful
