### PR TITLE
Add configurable visible tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Notifications = true
 RandomSongsCount = 100
 Scrobble = true
 SaveQueue = true
+# Valid tabs: Browse, Artists, Queue, Playlists, Radio, Server, Settings
+VisibleTabs = ["Browse", "Artists", "Queue", "Playlists", "Radio", "Server", "Settings"]
 ```
 
 | Field | Type | Default | Description |
@@ -114,6 +116,7 @@ SaveQueue = true
 | `RandomSongsCount` | `usize` | `250` | Number of random songs to fetch |
 | `Scrobble` | `bool` | `true` | Enable scrobbling (reporting played tracks to the server) |
 | `SaveQueue` | `bool` | `true` | Save and restore the play queue and current position on launch |
+| `VisibleTabs` | `string[]` | all tabs | Header tabs to show, in order. Valid values: `Browse`, `Artists`, `Queue`, `Playlists`, `Radio`, `Server`, `Settings` |
 
 Logs are written to `~/.config/ferrosonic/ferrosonic.log`.
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -69,14 +69,21 @@ impl App {
                 return Ok(());
             }
             // Page switching
-            (KeyCode::F(1), _) => {
-                state.page = Page::Browse;
+            (KeyCode::F(n), _) if (1..=7).contains(&n) => {
+                let visible_pages = state.visible_pages();
+                let Some(page) = visible_pages.get(n as usize - 1).copied() else {
+                    return Ok(());
+                };
+
+                state.page = page;
                 let on_starred = state.browse.selected_option == Some(SongOption::Starred);
                 let browse_tab = state.browse.browse_tab.clone();
-                let refresh_songs = on_starred
+                let refresh_songs = page == Page::Browse
+                    && on_starred
                     && browse_tab == BrowseTab::Songs
                     && state.browse.starred_songs_dirty;
-                let refresh_albums = on_starred
+                let refresh_albums = page == Page::Browse
+                    && on_starred
                     && browse_tab == BrowseTab::Albums
                     && state.browse.starred_albums_dirty;
 
@@ -90,30 +97,6 @@ impl App {
                     self.get_starred_albums().await;
                     self.state.write().await.browse.starred_albums_dirty = false;
                 }
-                return Ok(());
-            }
-            (KeyCode::F(2), _) => {
-                state.page = Page::Artists;
-                return Ok(());
-            }
-            (KeyCode::F(3), _) => {
-                state.page = Page::Queue;
-                return Ok(());
-            }
-            (KeyCode::F(4), _) => {
-                state.page = Page::Playlists;
-                return Ok(());
-            }
-            (KeyCode::F(5), _) => {
-                state.page = Page::Radio;
-                return Ok(());
-            }
-            (KeyCode::F(6), _) => {
-                state.page = Page::Server;
-                return Ok(());
-            }
-            (KeyCode::F(7), _) => {
-                state.page = Page::Settings;
                 return Ok(());
             }
             // Playback controls (global)

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -25,20 +25,20 @@ impl App {
         let state = self.state.read().await;
         let layout = state.layout.clone();
         let page = state.page;
+        let visible_pages = state.visible_pages();
         let duration = state.now_playing.duration;
         let radio_active = state.now_playing.radio_station.is_some();
         drop(state);
 
         // Check header area
         if y >= layout.header.y && y < layout.header.y + layout.header.height {
-            if let Some(region) = Header::region_at(layout.header, x, y) {
+            if let Some(region) = Header::region_at(layout.header, x, y, &visible_pages) {
                 match region {
                     HeaderRegion::Tab(tab_page) => {
                         let mut state = self.state.write().await;
                         state.page = tab_page;
 
-                        let on_starred =
-                            state.browse.selected_option == Some(SongOption::Starred);
+                        let on_starred = state.browse.selected_option == Some(SongOption::Starred);
                         let browse_tab = state.browse.browse_tab.clone();
                         let refresh_songs = on_starred
                             && browse_tab == BrowseTab::Songs

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -25,17 +25,15 @@ pub enum Page {
 }
 
 impl Page {
-    pub fn index(&self) -> usize {
-        match self {
-            Page::Browse => 0,
-            Page::Artists => 1,
-            Page::Queue => 2,
-            Page::Playlists => 3,
-            Page::Radio => 4,
-            Page::Server => 5,
-            Page::Settings => 6,
-        }
-    }
+    pub const DEFAULT_TABS: [Page; 7] = [
+        Page::Browse,
+        Page::Artists,
+        Page::Queue,
+        Page::Playlists,
+        Page::Radio,
+        Page::Server,
+        Page::Settings,
+    ];
 
     pub fn label(&self) -> &'static str {
         match self {
@@ -58,6 +56,39 @@ impl Page {
             Page::Radio => "F5",
             Page::Server => "F6",
             Page::Settings => "F7",
+        }
+    }
+
+    pub fn from_config_name(name: &str) -> Option<Self> {
+        match name
+            .to_ascii_lowercase()
+            .replace([' ', '-', '_'], "")
+            .as_str()
+        {
+            "browse" => Some(Page::Browse),
+            "artists" => Some(Page::Artists),
+            "queue" => Some(Page::Queue),
+            "playlists" => Some(Page::Playlists),
+            "radio" => Some(Page::Radio),
+            "server" => Some(Page::Server),
+            "settings" => Some(Page::Settings),
+            _ => None,
+        }
+    }
+
+    pub fn visible_from_config(names: &[String]) -> Vec<Self> {
+        let mut pages = Vec::new();
+        for name in names {
+            if let Some(page) = Page::from_config_name(name) {
+                if !pages.contains(&page) {
+                    pages.push(page);
+                }
+            }
+        }
+        if pages.is_empty() {
+            Page::DEFAULT_TABS.to_vec()
+        } else {
+            pages
         }
     }
 }
@@ -567,6 +598,50 @@ impl AppState {
     /// Clear the notification
     pub fn clear_notification(&mut self) {
         self.notification = None;
+    }
+
+    pub fn visible_pages(&self) -> Vec<Page> {
+        Page::visible_from_config(&self.config.visible_tabs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Page;
+
+    #[test]
+    fn visible_pages_use_default_when_not_configured() {
+        assert_eq!(Page::visible_from_config(&[]), Page::DEFAULT_TABS);
+    }
+
+    #[test]
+    fn visible_pages_follow_config_order() {
+        let names = vec![
+            "Artists".to_string(),
+            "Queue".to_string(),
+            "Playlists".to_string(),
+            "Browse".to_string(),
+        ];
+
+        assert_eq!(
+            Page::visible_from_config(&names),
+            vec![Page::Artists, Page::Queue, Page::Playlists, Page::Browse]
+        );
+    }
+
+    #[test]
+    fn visible_pages_ignore_unknown_and_duplicate_names() {
+        let names = vec![
+            "Queue".to_string(),
+            "Nope".to_string(),
+            "queue".to_string(),
+            "Server".to_string(),
+        ];
+
+        assert_eq!(
+            Page::visible_from_config(&names),
+            vec![Page::Queue, Page::Server]
+        );
     }
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -47,18 +47,6 @@ impl Page {
         }
     }
 
-    pub fn shortcut(&self) -> &'static str {
-        match self {
-            Page::Browse => "F1",
-            Page::Artists => "F2",
-            Page::Queue => "F3",
-            Page::Playlists => "F4",
-            Page::Radio => "F5",
-            Page::Server => "F6",
-            Page::Settings => "F7",
-        }
-    }
-
     pub fn from_config_name(name: &str) -> Option<Self> {
         match name
             .to_ascii_lowercase()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,6 +54,10 @@ pub struct Config {
     /// Save and restore queue on launch
     #[serde(rename = "SaveQueue", default = "Config::default_save_queue")]
     pub save_queue: bool,
+
+    /// Header tabs to show, in order. Empty uses the default tab list.
+    #[serde(rename = "VisibleTabs", default, skip_serializing_if = "Vec::is_empty")]
+    pub visible_tabs: Vec<String>,
 }
 
 impl Config {
@@ -181,6 +185,7 @@ mod tests {
 BaseURL = "https://example.com"
 Username = "testuser"
 Password = "testpass"
+VisibleTabs = ["Artists", "Queue", "Browse"]
 "#;
 
         let mut file = NamedTempFile::new().unwrap();
@@ -190,6 +195,7 @@ Password = "testpass"
         assert_eq!(config.base_url, "https://example.com");
         assert_eq!(config.username, "testuser");
         assert_eq!(config.password, "testpass");
+        assert_eq!(config.visible_tabs, ["Artists", "Queue", "Browse"]);
     }
 
     #[test]

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -14,14 +14,21 @@ use crate::ui::theme::ThemeColors;
 /// Header bar widget
 pub struct Header {
     current_page: Page,
+    visible_pages: Vec<Page>,
     playback_state: PlaybackState,
     colors: ThemeColors,
 }
 
 impl Header {
-    pub fn new(current_page: Page, playback_state: PlaybackState, colors: ThemeColors) -> Self {
+    pub fn new(
+        current_page: Page,
+        visible_pages: Vec<Page>,
+        playback_state: PlaybackState,
+        colors: ThemeColors,
+    ) -> Self {
         Self {
             current_page,
+            visible_pages,
             playback_state,
             colors,
         }
@@ -38,21 +45,19 @@ impl Widget for Header {
         let chunks = Layout::horizontal([Constraint::Min(40), Constraint::Length(30)]).split(area);
 
         // Page tabs
-        let titles: Vec<Line> = [
-            Page::Browse,
-            Page::Artists,
-            Page::Queue,
-            Page::Playlists,
-            Page::Radio,
-            Page::Server,
-            Page::Settings,
-        ]
-        .iter()
-        .map(|p: &Page| Line::from(format!("{} {}", p.shortcut(), p.label())))
-        .collect();
+        let titles: Vec<Line> = self
+            .visible_pages
+            .iter()
+            .map(|p: &Page| Line::from(format!("{} {}", p.shortcut(), p.label())))
+            .collect();
+        let selected = self
+            .visible_pages
+            .iter()
+            .position(|page| *page == self.current_page)
+            .unwrap_or(titles.len());
 
         let tabs = Tabs::new(titles)
-            .select(self.current_page.index())
+            .select(selected)
             .highlight_style(
                 Style::default()
                     .fg(self.colors.primary)
@@ -109,28 +114,19 @@ pub enum HeaderRegion {
 
 impl Header {
     /// Determine which region was clicked
-    pub fn region_at(area: Rect, x: u16, _y: u16) -> Option<HeaderRegion> {
+    pub fn region_at(area: Rect, x: u16, _y: u16, visible_pages: &[Page]) -> Option<HeaderRegion> {
         let chunks = Layout::horizontal([Constraint::Min(40), Constraint::Length(30)]).split(area);
 
         if x >= chunks[0].x && x < chunks[0].x + chunks[0].width {
             // Tab area — compute actual tab positions matching Tabs widget rendering.
             // Tabs renders: [pad][title][pad] [divider] [pad][title][pad] ...
             // Default padding = 1 space each side. Divider = " │ " = 3 chars.
-            let pages = [
-                Page::Browse,
-                Page::Artists,
-                Page::Queue,
-                Page::Playlists,
-                Page::Radio,
-                Page::Server,
-                Page::Settings,
-            ];
             let divider_width: u16 = 3; // " │ "
             let padding: u16 = 1; // 1 space each side
 
             let rel_x = x - chunks[0].x;
             let mut cursor: u16 = 0;
-            for (i, page) in pages.iter().enumerate() {
+            for (i, page) in visible_pages.iter().enumerate() {
                 let label = format!("{} {}", page.shortcut(), page.label());
                 let tab_width = padding + label.len() as u16 + padding;
                 if rel_x >= cursor && rel_x < cursor + tab_width {
@@ -138,7 +134,7 @@ impl Header {
                 }
                 cursor += tab_width;
                 // Add divider (except after the last tab)
-                if i < pages.len() - 1 {
+                if i < visible_pages.len() - 1 {
                     cursor += divider_width;
                 }
             }

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -33,6 +33,10 @@ impl Header {
             colors,
         }
     }
+
+    fn tab_label(index: usize, page: &Page) -> String {
+        format!("F{} {}", index + 1, page.label())
+    }
 }
 
 impl Widget for Header {
@@ -48,7 +52,8 @@ impl Widget for Header {
         let titles: Vec<Line> = self
             .visible_pages
             .iter()
-            .map(|p: &Page| Line::from(format!("{} {}", p.shortcut(), p.label())))
+            .enumerate()
+            .map(|(i, page)| Line::from(Header::tab_label(i, page)))
             .collect();
         let selected = self
             .visible_pages
@@ -127,7 +132,7 @@ impl Header {
             let rel_x = x - chunks[0].x;
             let mut cursor: u16 = 0;
             for (i, page) in visible_pages.iter().enumerate() {
-                let label = format!("{} {}", page.shortcut(), page.label());
+                let label = Header::tab_label(i, page);
                 let tab_width = padding + label.len() as u16 + padding;
                 if rel_x >= cursor && rel_x < cursor + tab_width {
                     return Some(HeaderRegion::Tab(*page));

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -72,7 +72,12 @@ pub fn draw(frame: &mut Frame, state: &AppState, mutations: &mut RenderMutations
 
     // Render header
     let colors = *state.settings_state.theme_colors();
-    let header = Header::new(state.page, state.now_playing.state, colors);
+    let header = Header::new(
+        state.page,
+        state.visible_pages(),
+        state.now_playing.state,
+        colors,
+    );
     frame.render_widget(header, header_area);
 
     // Render cava visualizer if active


### PR DESCRIPTION
## Summary

- add a VisibleTabs config option for choosing which header tabs are shown and in what order
- keep the existing default tab list when VisibleTabs is omitted or empty
- make header function-key labels and F1-F7 navigation follow the visible tab order
- document the new config option in the README

## Validation

- cargo check
- cargo test visible_pages
- cargo test test_config_parse
- cargo test

## Possible follow-ups

If this direction looks good, generated config output could include a comment listing valid tab names, and the Settings page could eventually expose tab visibility/order controls.