### PR TITLE
Display album and remaining queue length

### DIFF
--- a/src/ui/pages/queue.rs
+++ b/src/ui/pages/queue.rs
@@ -8,7 +8,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::state::{AppState, RenderMutations};
+use crate::app::state::{format_duration, AppState, RenderMutations};
 
 /// Render the queue page.
 ///
@@ -17,9 +17,30 @@ use crate::app::state::{AppState, RenderMutations};
 pub fn render(frame: &mut Frame, area: Rect, state: &AppState, mutations: &mut RenderMutations) {
     let colors = *state.settings_state.theme_colors();
 
+    // Sum durations of the current and upcoming tracks (already-played tracks
+    // are excluded) so the title can show how much listening time is left.
+    let start = state.queue_position.unwrap_or(0);
+    let remaining_secs: i64 = state
+        .queue
+        .iter()
+        .skip(start)
+        .filter_map(|song| song.duration)
+        .map(i64::from)
+        .sum();
+
+    let title = if remaining_secs > 0 {
+        format!(
+            " Queue ({}) [{} left] ",
+            state.queue.len(),
+            format_duration(remaining_secs as f64)
+        )
+    } else {
+        format!(" Queue ({}) ", state.queue.len())
+    };
+
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Queue ({}) ", state.queue.len()))
+        .title(title)
         .border_style(Style::default().fg(colors.border_focused));
 
     if state.queue.is_empty() {

--- a/src/ui/styled_lines.rs
+++ b/src/ui/styled_lines.rs
@@ -1,3 +1,4 @@
+use crate::app::state::format_duration;
 use crate::subsonic::models::{Album, Child};
 use crate::ui::theme::ThemeColors;
 
@@ -112,11 +113,18 @@ pub fn get_album_line<'a>(
         (false, false) => format!(" - {} {}", artist, year_str),
     };
 
+    let duration_text = album
+        .duration
+        .filter(|&d| d > 0)
+        .map(|d| format!(" [{}]", format_duration(d as f64)))
+        .unwrap_or_default();
+
     Line::from(vec![
         Span::styled(indicator, Style::default().fg(colors.playing)),
         Span::styled(star_indicator, Style::default().fg(colors.playing)),
         Span::styled(album.name.clone(), Style::default().fg(title_color)),
         Span::styled(meta_text, Style::default().fg(meta_color)),
+        Span::styled(duration_text, Style::default().fg(meta_color)),
     ])
 }
 


### PR DESCRIPTION
Show the album's total duration in the Albums list (browse/search tab) and the remaining listening time in the Queue tab title.

- get_album_line now appends [MM:SS]/[HH:MM:SS] from the Album.duration field (already populated by getAlbumList2), omitted when unavailable.
- The Queue block title shows "[HH:MM:SS left]", summing the current and upcoming tracks (skipping already-played ones via queue_position).

Both reuse the existing format_duration helper for consistent formatting.

Closes #141