### PR TITLE
Add keyboard volume control in the TUI

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -119,6 +119,22 @@ impl App {
                 drop(state);
                 return self.prev_track().await;
             }
+            // Volume up 5% ('+' / '=')
+            (KeyCode::Char('+') | KeyCode::Char('='), _) => {
+                let vol = state.adjust_volume(5);
+                state.notify(format!("Volume: {}%", vol));
+                drop(state);
+                let _ = self.mpv.set_volume(vol);
+                return Ok(());
+            }
+            // Volume down 5% ('-' / '_')
+            (KeyCode::Char('-') | KeyCode::Char('_'), _) => {
+                let vol = state.adjust_volume(-5);
+                state.notify(format!("Volume: {}%", vol));
+                drop(state);
+                let _ = self.mpv.set_volume(vol);
+                return Ok(());
+            }
             // Seek backward 5 seconds
             (KeyCode::Char('H'), KeyModifiers::SHIFT) => {
                 drop(state);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -461,6 +461,7 @@ impl App {
                     }
                     AudioAction::SetVolume(vol) => {
                         let _ = self.mpv.set_volume(vol);
+                        self.state.write().await.volume = vol.clamp(0, 100);
                     }
                 }
             }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -477,6 +477,8 @@ pub struct AppState {
     pub queue: Vec<Child>,
     /// Current position in queue
     pub queue_position: Option<usize>,
+    /// Playback volume (0-100), session-persistent across track changes
+    pub volume: i32,
     /// Browse page state
     pub browse: BrowseState,
     /// Artists page state
@@ -553,8 +555,16 @@ impl AppState {
         state.settings_state.save_queue_enabled = config.save_queue;
         // Default to All songs so navigation and rendering start in sync
         state.browse.selected_option = Some(SongOption::All);
+        // mpv starts at full volume; mirror that in state for the UI
+        state.volume = 100;
 
         state
+    }
+
+    /// Adjust the volume by `delta`, clamped to 0-100, returning the new value.
+    pub fn adjust_volume(&mut self, delta: i32) -> i32 {
+        self.volume = (self.volume + delta).clamp(0, 100);
+        self.volume
     }
 
     /// Get the currently playing song from the queue
@@ -661,6 +671,28 @@ mod tests {
         let state = AppState::new(Config::default());
 
         assert_eq!(state.page, Page::Browse);
+    }
+
+    #[test]
+    fn app_state_starts_at_full_volume() {
+        let state = AppState::new(Config::default());
+        assert_eq!(state.volume, 100);
+    }
+
+    #[test]
+    fn adjust_volume_clamps_to_0_100() {
+        let mut state = AppState::new(Config::default());
+
+        assert_eq!(state.adjust_volume(-5), 95);
+        assert_eq!(state.adjust_volume(10), 100); // clamps at the top
+        assert_eq!(state.adjust_volume(5), 100); // stays clamped
+
+        // Drive it down past zero and confirm the floor.
+        for _ in 0..25 {
+            state.adjust_volume(-5);
+        }
+        assert_eq!(state.volume, 0);
+        assert_eq!(state.adjust_volume(-5), 0);
     }
 }
 

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -2,10 +2,10 @@
 
 use ratatui::{
     buffer::Buffer,
-    layout::{Constraint, Layout, Rect},
+    layout::{Alignment, Constraint, Layout, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::Widget,
+    widgets::{Paragraph, Widget},
 };
 
 use crate::app::state::{Notification, Page};
@@ -15,6 +15,7 @@ use crate::ui::theme::ThemeColors;
 pub struct Footer<'a> {
     page: Page,
     sample_rate: Option<u32>,
+    volume: i32,
     notification: Option<&'a Notification>,
     colors: ThemeColors,
 }
@@ -24,6 +25,7 @@ impl<'a> Footer<'a> {
         Self {
             page,
             sample_rate: None,
+            volume: 100,
             notification: None,
             colors,
         }
@@ -31,6 +33,11 @@ impl<'a> Footer<'a> {
 
     pub fn sample_rate(mut self, rate: Option<u32>) -> Self {
         self.sample_rate = rate;
+        self
+    }
+
+    pub fn volume(mut self, volume: i32) -> Self {
+        self.volume = volume;
         self
     }
 
@@ -45,6 +52,7 @@ impl<'a> Footer<'a> {
             ("p/Space", "Pause"),
             ("h", "Prev"),
             ("l", "Next"),
+            ("+/-", "Vol"),
         ];
 
         match self.page {
@@ -150,7 +158,15 @@ impl Widget for Footer<'_> {
             buf.set_line(chunks[0].x, chunks[0].y, &line, chunks[0].width);
         }
 
-        // Right side: sample rate / status
+        // Right side: volume and sample rate, right-aligned
+        let mut spans = vec![
+            Span::styled("Vol ", Style::default().fg(self.colors.muted)),
+            Span::styled(
+                format!("{}%", self.volume),
+                Style::default().fg(self.colors.accent),
+            ),
+        ];
+
         if let Some(rate) = self.sample_rate {
             let khz = rate as f64 / 1000.0;
             let rate_str = if khz == khz.floor() {
@@ -158,13 +174,18 @@ impl Widget for Footer<'_> {
             } else {
                 format!("{:.1}kHz", khz)
             };
-            let x = chunks[1].x + chunks[1].width.saturating_sub(rate_str.len() as u16);
-            buf.set_string(
-                x,
-                chunks[1].y,
-                &rate_str,
+            spans.push(Span::styled(
+                " │ ",
+                Style::default().fg(self.colors.secondary),
+            ));
+            spans.push(Span::styled(
+                rate_str,
                 Style::default().fg(self.colors.success),
-            );
+            ));
         }
+
+        Paragraph::new(Line::from(spans))
+            .alignment(Alignment::Right)
+            .render(chunks[1], buf);
     }
 }

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -118,6 +118,7 @@ pub fn draw(frame: &mut Frame, state: &AppState, mutations: &mut RenderMutations
     // Render footer
     let footer = Footer::new(state.page, colors)
         .sample_rate(state.now_playing.sample_rate)
+        .volume(state.volume)
         .notification(state.notification.as_ref());
     frame.render_widget(footer, footer_area);
 }


### PR DESCRIPTION
Volume could previously only be changed via MPRIS clients. Add native TUI controls, an on-screen display, and session-persistent state.

- +/= raises volume by 5%, -/_ lowers it (global keybindings, bypassed while typing in server fields or search filters).
- Footer right side shows "Vol N%" alongside the sample rate, plus a "+/-:Vol" hint in the keybind list.
- AppState gains a volume field (default 100) with an adjust_volume helper that clamps to 0-100; volume persists across track changes via mpv's global volume property.
- MPRIS SetVolume now syncs state.volume so the display stays accurate for external changes.

Closes #59