### PR TITLE
Spawn mpv with --load-scripts=no to avoid duplicate MPRIS entries

### DIFF
--- a/src/audio/mpv.rs
+++ b/src/audio/mpv.rs
@@ -89,6 +89,7 @@ impl MpvController {
             .arg("--idle") // Stay running when nothing playing
             .arg("--no-video") // Audio only
             .arg("--no-terminal") // No MPV UI
+            .arg("--load-scripts=no") // No user/global mpv scripts: ferrosonic ships its own MPRIS (avoids duplicate player entries)
             .arg("--gapless-audio=yes") // Gapless playback between tracks
             .arg("--prefetch-playlist=yes") // Pre-buffer next track
             .arg("--cache=yes") // Enable cache for network streams


### PR DESCRIPTION
ferrosonic spawns the system mpv binary, which auto-loads scripts from /etc/mpv/scripts and ~/.config/mpv/scripts. With mpv-mpris installed globally (a common setup for media keys), the spawned child registers org.mpris.MediaPlayer2.mpv alongside ferrosonic's own MPRIS name — the same playback appears as two players and confuses media-key multiplexers and widgets.

Fix: pass --load-scripts=no when spawning the audio child; it is headless and needs no user scripts. Standalone mpv usage is unaffected.

Tested on Fedora 44 / KDE Plasma 6: before the change, busctl --user list showed org.mpris.MediaPlayer2.ferrosonic plus a duplicate ...mpv entry from the spawned child; after — only ferrosonic's own entry remains (plus unrelated players).