### PR TITLE
fix: Prevent mpv window even if network profile has force-window set

### DIFF
--- a/src/audio/mpv.rs
+++ b/src/audio/mpv.rs
@@ -88,6 +88,7 @@ impl MpvController {
         let child = Command::new("mpv")
             .arg("--idle") // Stay running when nothing playing
             .arg("--no-video") // Audio only
+            .arg("--force-window=no") // Never show a window, even if user config has force-window set
             .arg("--no-terminal") // No MPV UI
             .arg("--load-scripts=no") // No user/global mpv scripts: ferrosonic ships its own MPRIS (avoids duplicate player entries)
             .arg("--gapless-audio=yes") // Gapless playback between tracks


### PR DESCRIPTION
Hi,

I love ferrosonic and it's an amazing TUI player (for my gonic server), but there was one remaining problem for me - the mpv window would keep popping up.

My Problem:

In my `~/.config/mpv/mpv.conf` I have:

```conf
[network]
force-window=immediate
```

I rely on that profile so my manual mpv usage (yt mainly) opens a window immediately. But mpv auto-applies the [network] profile to streams, and gonic serves everything over http, so my window-forcing setting leaks into ferrosonic's playback. `--no-video` only disables video decoding - it doesn't stop `--force-window` from creating a window. The result: an mpv window pops up for every song and closes/reopens as mpv recreates the VO per file load, which I think the original `--no-video` tried to avoid.

This PR also passes `--force-window=no` on the command line alongside `--no-video`.
Since mpv resolves cli options after config file, we essentially 'restore' the mpv-default `--force-window=no` behavior with this (i.e. changes nothing for users who don't set this).

Hope this is helpful!