### PR TITLE
fix(audio): use --gapless-audio=weak so bit-perfect output follows the source

### DIFF
--- a/src/audio/mpv.rs
+++ b/src/audio/mpv.rs
@@ -91,7 +91,11 @@ impl MpvController {
             .arg("--force-window=no") // Never show a window, even if user config has force-window set
             .arg("--no-terminal") // No MPV UI
             .arg("--load-scripts=no") // No user/global mpv scripts: ferrosonic ships its own MPRIS (avoids duplicate player entries)
-            .arg("--gapless-audio=yes") // Gapless playback between tracks
+            // Gapless within a format, but reopen the audio device when the sample
+            // rate or format changes, so bit-perfect output follows the source.
+            // "yes" would hold the device open and resample every later track to
+            // whatever rate the first one opened it at.
+            .arg("--gapless-audio=weak")
             .arg("--prefetch-playlist=yes") // Pre-buffer next track
             .arg("--cache=yes") // Enable cache for network streams
             .arg("--cache-secs=120") // Cache up to 2 minutes ahead


### PR DESCRIPTION
## Problem

`MpvPlayer::start` launches mpv with `--gapless-audio=yes`. That keeps the audio device open across track boundaries *even when the format changes*, so on a device held in exclusive mode the hardware stays pinned to whatever the first track needed and every later track of a different sample rate gets resampled to match. That is the opposite of the bit-perfect playback ferrosonic advertises, and it also overrides whatever the user set in `mpv.conf`.

It is invisible from the UI: the footer reports the *source* rate correctly while the device is running at the old one.

## Reproduction

Navidrome library, Marantz CD 50n over USB, mpv in exclusive mode (`ao=alsa`, `audio-device=alsa/hw:CARD=C50n,DEV=0`, `audio-exclusive=yes`). Rate read straight from the kernel rather than the UI:

```
# start on a 44.1kHz album, then play a 48kHz one
$ cat /proc/asound/card4/pcm0p/sub0/hw_params
rate: 44100 (44100/1)      # 48kHz source, resampled

# reverse: start on 48kHz, then play a 44.1kHz album
rate: 48000 (48000/1)      # 44.1kHz source, resampled
```

## Fix

`weak` keeps gapless playback within a format and only reinitialises the output when the sample rate or format actually changes — which is exactly when a bit-perfect chain *should* reopen the device.

With the change, the device follows the source:

| Source | `hw_params` rate | period_size |
|---|---|---|
| 44.1kHz / 16-bit FLAC | `44100` | 882 |
| 48kHz / 24-bit FLAC | `48000` | 1200 |
| 96kHz / 24-bit FLAC | `96000` | 2400 |

(`format` stays `S32_LE` throughout — the only format that DAC accepts, so samples are padded rather than converted.)

I confirmed the mechanism before touching the code by setting the property at runtime over the mpv IPC socket (`{"command":["set_property","gapless-audio","weak"]}`): the next track change reopened the device at the correct rate, and a later 96kHz album switched it to 96000.

## Trade-off

`weak` costs a device reinit at format boundaries — a mixed-rate queue gets a brief gap where `yes` would have crossfaded straight through (at the wrong rate). Within an album, or any run of same-format tracks, gapless is unaffected. For a player whose headline feature is bit-perfect output that seems like the right side to err on, but happy to put it behind a config flag instead if you'd rather keep the current default.